### PR TITLE
fix: use pointer-based patch struct for EstimateTarget updates

### DIFF
--- a/ihpa-controller/controllers/estimator.go
+++ b/ihpa-controller/controllers/estimator.go
@@ -54,6 +54,21 @@ type EstimateTarget struct {
 type EstimateOperation struct {
 	Operator EstimateOperator
 	Target   EstimateTarget
+	Patch    *EstimateTargetPatch
+}
+
+// EstimateTargetPatch represents a partial update to an EstimateTarget.
+// Only non-nil fields will be applied. This allows callers to distinguish
+// between "field not provided" (nil) and "field set to zero value" (e.g. *0, *"").
+type EstimateTargetPatch struct {
+	ID             string
+	EstimateMode   *string
+	GapMinutes     *int
+	MetricProvider metricprovider.MetricProvider
+	MetricName     *string
+	MetricTags     *[]string
+	BaseMetricName *string
+	BaseMetricTags *[]string
 }
 
 type EstimateDatum struct {
@@ -156,14 +171,14 @@ func estimatorHandler(opeCh <-chan *EstimateOperation, log logr.Logger) {
 				go et.estimator()
 				estimateTargets = append(estimateTargets, et)
 
-			case EstimateUpdate:
-				patch := ope.Target
-				log.V(LogicMessageLogLevel).Info("update estimator", "id", patch.ID)
-				for i, et := range estimateTargets {
-					if et.ID == patch.ID {
-						if err := et.updateEstimateTarget(&patch); err != nil {
-							log.V(LogicMessageLogLevel).Info("update estimator error", "error_msg", err)
-						}
+		case EstimateUpdate:
+			patch := ope.Patch
+			log.V(LogicMessageLogLevel).Info("update estimator", "id", patch.ID)
+			for i, et := range estimateTargets {
+				if et.ID == patch.ID {
+					if err := et.updateEstimateTarget(patch); err != nil {
+						log.V(LogicMessageLogLevel).Info("update estimator error", "error_msg", err)
+					}
 
 						close(et.estimatorStopCh)
 						et.estimatorStopCh = make(chan struct{})
@@ -337,32 +352,31 @@ estimatorLoop:
 	et.V(LogicMessageLogLevel).Info("stop estimator", "id", et.ID)
 }
 
-func (base *EstimateTarget) updateEstimateTarget(patch *EstimateTarget) error {
+func (base *EstimateTarget) updateEstimateTarget(patch *EstimateTargetPatch) error {
 	if base.ID != patch.ID {
 		return fmt.Errorf("target id is not match: base=%s, patch=%s", base.ID, patch.ID)
 	}
 
-	// TODO: look for a smart way to overwrite by only not zero value
-	if patch.EstimateMode != "" {
-		base.EstimateMode = patch.EstimateMode
+	if patch.EstimateMode != nil {
+		base.EstimateMode = *patch.EstimateMode
 	}
-	if patch.GapMinutes != 0 {
-		base.GapMinutes = patch.GapMinutes
+	if patch.GapMinutes != nil {
+		base.GapMinutes = *patch.GapMinutes
 	}
 	if patch.MetricProvider != nil {
 		base.MetricProvider = patch.MetricProvider
 	}
-	if patch.MetricName != "" {
-		base.MetricName = patch.MetricName
+	if patch.MetricName != nil {
+		base.MetricName = *patch.MetricName
 	}
 	if patch.MetricTags != nil {
-		base.MetricTags = patch.MetricTags
+		base.MetricTags = *patch.MetricTags
 	}
-	if patch.BaseMetricName != "" {
-		base.BaseMetricName = patch.BaseMetricName
+	if patch.BaseMetricName != nil {
+		base.BaseMetricName = *patch.BaseMetricName
 	}
 	if patch.BaseMetricTags != nil {
-		base.BaseMetricTags = patch.BaseMetricTags
+		base.BaseMetricTags = *patch.BaseMetricTags
 	}
 
 	return nil

--- a/ihpa-controller/controllers/estimator_controller.go
+++ b/ihpa-controller/controllers/estimator_controller.go
@@ -121,14 +121,14 @@ func (r *EstimatorReconciler) Reconcile(req ctrl.Request) (ctrl.Result, error) {
 			"baseMetricName", est.Spec.BaseMetricName, "baseMetricTags", est.Spec.BaseMetricTags)
 		r.opeCh <- &EstimateOperation{
 			Operator: EstimateUpdate,
-			Target: EstimateTarget{
+			Patch: &EstimateTargetPatch{
 				ID:             req.String(),
-				EstimateMode:   est.Spec.Mode,
-				GapMinutes:     int(est.Spec.GapMinutes),
-				MetricName:     est.Spec.MetricName,
-				MetricTags:     est.Spec.MetricTags,
-				BaseMetricName: est.Spec.BaseMetricName,
-				BaseMetricTags: est.Spec.BaseMetricTags,
+				EstimateMode:   &est.Spec.Mode,
+				GapMinutes:     ptrToInt(int(est.Spec.GapMinutes)),
+				MetricName:     &est.Spec.MetricName,
+				MetricTags:     &est.Spec.MetricTags,
+				BaseMetricName: &est.Spec.BaseMetricName,
+				BaseMetricTags: &est.Spec.BaseMetricTags,
 				MetricProvider: mpconfig.ConvertMetricProvider(est.Spec.Provider.DeepCopy()).ActiveProvider(),
 			},
 		}
@@ -171,4 +171,8 @@ func (r *EstimatorReconciler) SetupWithManager(mgr ctrl.Manager) error {
 		For(&ihpav1beta2.Estimator{}).
 		Owns(&corev1.ConfigMap{}).
 		Complete(r)
+}
+
+func ptrToInt(v int) *int {
+	return &v
 }

--- a/ihpa-controller/controllers/estimator_test.go
+++ b/ihpa-controller/controllers/estimator_test.go
@@ -199,10 +199,8 @@ func TestAdjustYHat(t *testing.T) {
 
 func TestUpdateEstimateTarget(t *testing.T) {
 	dummyByteCh1 := make(chan []byte)
-	dummyByteCh2 := make(chan []byte)
 
 	dummyStructCh1 := make(chan struct{})
-	dummyStructCh2 := make(chan struct{})
 
 	dummyProvider1 := &datadog.Datadog{
 		APIKey: "xxx",
@@ -213,9 +211,13 @@ func TestUpdateEstimateTarget(t *testing.T) {
 		APPKey: "bbb",
 	}
 
+	strPtr := func(s string) *string { return &s }
+	intPtr := func(i int) *int { return &i }
+	sliceStrPtr := func(s []string) *[]string { return &s }
+
 	tests := []struct {
 		base     EstimateTarget
-		patch    EstimateTarget
+		patch    EstimateTargetPatch
 		expected EstimateTarget
 		hasError bool
 	}{
@@ -232,14 +234,14 @@ func TestUpdateEstimateTarget(t *testing.T) {
 				DataCh:          dummyByteCh1,
 				estimatorStopCh: dummyStructCh1,
 			},
-			patch: EstimateTarget{
+			patch: EstimateTargetPatch{
 				ID:             "a",
-				EstimateMode:   "adjust",
-				GapMinutes:     5,
-				MetricName:     "metric2",
-				MetricTags:     []string{"hello"},
-				BaseMetricName: "base-metric2",
-				BaseMetricTags: []string{"hello", "foo"},
+				EstimateMode:   strPtr("adjust"),
+				GapMinutes:     intPtr(5),
+				MetricName:     strPtr("metric2"),
+				MetricTags:     sliceStrPtr([]string{"hello"}),
+				BaseMetricName: strPtr("base-metric2"),
+				BaseMetricTags: sliceStrPtr([]string{"hello", "foo"}),
 				MetricProvider: dummyProvider2,
 			},
 			expected: EstimateTarget{
@@ -269,10 +271,10 @@ func TestUpdateEstimateTarget(t *testing.T) {
 				DataCh:          dummyByteCh1,
 				estimatorStopCh: dummyStructCh1,
 			},
-			patch: EstimateTarget{
+			patch: EstimateTargetPatch{
 				ID:             "a",
-				EstimateMode:   "adjust",
-				BaseMetricTags: []string{"hello", "foo"},
+				EstimateMode:   strPtr("adjust"),
+				BaseMetricTags: sliceStrPtr([]string{"hello", "foo"}),
 			},
 			expected: EstimateTarget{
 				ID:              "a",
@@ -301,10 +303,8 @@ func TestUpdateEstimateTarget(t *testing.T) {
 				DataCh:          dummyByteCh1,
 				estimatorStopCh: dummyStructCh1,
 			},
-			patch: EstimateTarget{
-				ID:              "a",
-				DataCh:          dummyByteCh2,
-				estimatorStopCh: dummyStructCh2,
+			patch: EstimateTargetPatch{
+				ID: "a",
 			},
 			expected: EstimateTarget{
 				ID:              "a",
@@ -312,6 +312,102 @@ func TestUpdateEstimateTarget(t *testing.T) {
 				GapMinutes:      10,
 				MetricName:      "metric1",
 				MetricTags:      []string{"hello", "world"},
+				BaseMetricName:  "base-metric1",
+				BaseMetricTags:  []string{"hello", "world", "foo"},
+				MetricProvider:  dummyProvider1,
+				DataCh:          dummyByteCh1,
+				estimatorStopCh: dummyStructCh1,
+			},
+			hasError: false,
+		},
+		{
+			// Test: set GapMinutes to 0 (zero value) via pointer
+			base: EstimateTarget{
+				ID:              "a",
+				EstimateMode:    "raw",
+				GapMinutes:      10,
+				MetricName:      "metric1",
+				MetricTags:      []string{"hello", "world"},
+				BaseMetricName:  "base-metric1",
+				BaseMetricTags:  []string{"hello", "world", "foo"},
+				MetricProvider:  dummyProvider1,
+				DataCh:          dummyByteCh1,
+				estimatorStopCh: dummyStructCh1,
+			},
+			patch: EstimateTargetPatch{
+				ID:         "a",
+				GapMinutes: intPtr(0),
+			},
+			expected: EstimateTarget{
+				ID:              "a",
+				EstimateMode:    "raw",
+				GapMinutes:      0,
+				MetricName:      "metric1",
+				MetricTags:      []string{"hello", "world"},
+				BaseMetricName:  "base-metric1",
+				BaseMetricTags:  []string{"hello", "world", "foo"},
+				MetricProvider:  dummyProvider1,
+				DataCh:          dummyByteCh1,
+				estimatorStopCh: dummyStructCh1,
+			},
+			hasError: false,
+		},
+		{
+			// Test: set MetricName to "" (zero value) via pointer
+			base: EstimateTarget{
+				ID:              "a",
+				EstimateMode:    "raw",
+				GapMinutes:      10,
+				MetricName:      "metric1",
+				MetricTags:      []string{"hello", "world"},
+				BaseMetricName:  "base-metric1",
+				BaseMetricTags:  []string{"hello", "world", "foo"},
+				MetricProvider:  dummyProvider1,
+				DataCh:          dummyByteCh1,
+				estimatorStopCh: dummyStructCh1,
+			},
+			patch: EstimateTargetPatch{
+				ID:         "a",
+				MetricName: strPtr(""),
+			},
+			expected: EstimateTarget{
+				ID:              "a",
+				EstimateMode:    "raw",
+				GapMinutes:      10,
+				MetricName:      "",
+				MetricTags:      []string{"hello", "world"},
+				BaseMetricName:  "base-metric1",
+				BaseMetricTags:  []string{"hello", "world", "foo"},
+				MetricProvider:  dummyProvider1,
+				DataCh:          dummyByteCh1,
+				estimatorStopCh: dummyStructCh1,
+			},
+			hasError: false,
+		},
+		{
+			// Test: set MetricTags to empty slice via pointer
+			base: EstimateTarget{
+				ID:              "a",
+				EstimateMode:    "raw",
+				GapMinutes:      10,
+				MetricName:      "metric1",
+				MetricTags:      []string{"hello", "world"},
+				BaseMetricName:  "base-metric1",
+				BaseMetricTags:  []string{"hello", "world", "foo"},
+				MetricProvider:  dummyProvider1,
+				DataCh:          dummyByteCh1,
+				estimatorStopCh: dummyStructCh1,
+			},
+			patch: EstimateTargetPatch{
+				ID:         "a",
+				MetricTags: sliceStrPtr([]string{}),
+			},
+			expected: EstimateTarget{
+				ID:              "a",
+				EstimateMode:    "raw",
+				GapMinutes:      10,
+				MetricName:      "metric1",
+				MetricTags:      []string{},
 				BaseMetricName:  "base-metric1",
 				BaseMetricTags:  []string{"hello", "world", "foo"},
 				MetricProvider:  dummyProvider1,
@@ -333,9 +429,9 @@ func TestUpdateEstimateTarget(t *testing.T) {
 				DataCh:          dummyByteCh1,
 				estimatorStopCh: dummyStructCh1,
 			},
-			patch: EstimateTarget{
+			patch: EstimateTargetPatch{
 				ID:           "b",
-				EstimateMode: "adjust",
+				EstimateMode: strPtr("adjust"),
 			},
 			expected: EstimateTarget{},
 			hasError: true,


### PR DESCRIPTION
## 概要

Issue #15 の対応です。

 の予測値上書きロジックを改善し、ゼロ値と「未設定」を区別できるようにしました。

## 背景

 に以下のTODOがありました。

```
// TODO: look for a smart way to overwrite by only not zero value
```

従来の実装では、フィールドのゼロ値チェック（, , ）で「未設定」と「ゼロ値」を区別していたため、以下の問題がありました：

- `GapMinutes` を 0 に設定できない（0 は「未設定」と同じ扱い）
- `MetricName` や `BaseMetricName` を空文字列に設定できない
- `EstimateMode` を空文字列に設定できない

## 変更内容

- `EstimateTargetPatch` 構造体を新規追加（ポインタフィールド使用）
  - `*string`, `*int`, `*[]string` により `nil` = 未設定、非nil = 更新を明確に区別
- `EstimateOperation` に `Patch *EstimateTargetPatch` フィールドを追加
- `updateEstimateTarget` を `*EstimateTargetPatch` 引数に変更
- `estimator_controller.go` でポインタベースのパッチを構築するよう更新
- テストケースに以下を追加:
  - `GapMinutes` を 0 に設定するケース
  - `MetricName` を空文字列に設定するケース
  - `MetricTags` を空スライスに設定するケース
  - 全フィールド未設定（IDのみ）のケース

## テスト

```
=== RUN   TestUpdateEstimateTarget
--- PASS: TestUpdateEstimateTarget (0.00s)
```

既存のテスト（TestAdjustYHat, TestReadEstimateDataAsCSV, TestJoinEstimateData, TestPastEstimateDatumQueue*）も全てPASS。

## 関連Issue

Closes #15