### PR TITLE
feat: implement Prometheus metric provider

### DIFF
--- a/README-jp.md
+++ b/README-jp.md
@@ -44,7 +44,18 @@ kubectl patch ds <your_datadog_agent> -p "{\"spec\":{\"template\":{\"spec\":{\"c
 
 ### Prometheus
 
-いつか
+IHPAはメトリクスプロバイダとしてPrometheusをサポートしています。`metricProvider`セクションに`prometheus`プロバイダソースを設定します：
+
+```yaml
+metricProvider:
+  name: prometheus
+  prometheus:
+    url: "http://prometheus-server:9090"
+    pushgatewayUrl: "http://prometheus-pushgateway:9091"
+```
+
+- `url`: メトリクスのクエリに使用するPrometheusサーバーのURL
+- `pushgatewayUrl`: 予測メトリクスの送信に使用するPrometheus PushgatewayのURL
 
 ## Usage
 
@@ -65,7 +76,7 @@ Intelligent HPA のマニフェストについて説明します。
         - 許容値: `adjust`, `raw` (default: `adjust`)
 - `metricProvider`
     - メトリクスを取得・送信するプロバイダを設定します
-    - 現在は Datadog のみ対応しています
+    - Datadog と Prometheus に対応しています
 - `template`
     - HPA のマニフェストを記述します
     - HPA から移行する場合はそのままここにコピーしてください

--- a/README.md
+++ b/README.md
@@ -46,7 +46,18 @@ kubectl patch ds <your_datadog_agent> -p "{\"spec\":{\"template\":{\"spec\":{\"c
 
 ### Prometheus
 
-not yet implemented
+IHPA supports Prometheus as a metric provider. Configure the `metricProvider` section with `prometheus` provider source:
+
+```yaml
+metricProvider:
+  name: prometheus
+  prometheus:
+    url: "http://prometheus-server:9090"
+    pushgatewayUrl: "http://prometheus-pushgateway:9091"
+```
+
+- `url`: Prometheus server URL for querying metrics
+- `pushgatewayUrl`: Prometheus Pushgateway URL for sending forecast metrics
 
 ## Usage
 
@@ -67,7 +78,7 @@ IHPA manifest has some field below:
         - Allowable: `adjust`, `raw` (default: `adjust`)
 - `metricProvider`
     - Provider for sending and fetching metrics
-    - Only Datadog is supported now
+    - Datadog and Prometheus are supported
 - `template`
     - Almost same template as HorizontalPodAutoscaler
     - You can copy/paste HPA manifests to this field

--- a/ihpa-controller/api/v1beta1/intelligenthorizontalpodautoscaler_types.go
+++ b/ihpa-controller/api/v1beta1/intelligenthorizontalpodautoscaler_types.go
@@ -121,7 +121,13 @@ type DatadogProviderSource struct {
 }
 
 // PrometheusProviderSource defines parameters for accessing Prometheus.
-type PrometheusProviderSource struct{}
+type PrometheusProviderSource struct {
+	// URL is the address of the Prometheus server for querying metrics.
+	URL string `json:"url,omitempty"`
+
+	// PushgatewayURL is the address of the Prometheus Pushgateway for sending metrics.
+	PushgatewayURL string `json:"pushgatewayUrl,omitempty"`
+}
 
 // IntelligentHorizontalPodAutoscalerStatus defines the observed state of IntelligentHorizontalPodAutoscaler
 type IntelligentHorizontalPodAutoscalerStatus struct {

--- a/ihpa-controller/api/v1beta2/intelligenthorizontalpodautoscaler_types.go
+++ b/ihpa-controller/api/v1beta2/intelligenthorizontalpodautoscaler_types.go
@@ -168,7 +168,13 @@ type DatadogProviderSource struct {
 }
 
 // PrometheusProviderSource defines parameters for accessing Prometheus.
-type PrometheusProviderSource struct{}
+type PrometheusProviderSource struct {
+	// URL is the address of the Prometheus server for querying metrics.
+	URL string `json:"url,omitempty"`
+
+	// PushgatewayURL is the address of the Prometheus Pushgateway for sending metrics.
+	PushgatewayURL string `json:"pushgatewayUrl,omitempty"`
+}
 
 // IntelligentHorizontalPodAutoscalerStatus defines the observed state of IntelligentHorizontalPodAutoscaler
 type IntelligentHorizontalPodAutoscalerStatus struct {

--- a/ihpa-controller/config/crd/bases/ihpa.ake.cyberagent.co.jp_estimators.yaml
+++ b/ihpa-controller/config/crd/bases/ihpa.ake.cyberagent.co.jp_estimators.yaml
@@ -137,6 +137,15 @@ spec:
                   prometheus:
                     description: PrometheusProviderSource defines parameters for accessing
                       Prometheus.
+                    properties:
+                      pushgatewayUrl:
+                        description: PushgatewayURL is the address of the Prometheus
+                          Pushgateway for sending metrics.
+                        type: string
+                      url:
+                        description: URL is the address of the Prometheus server for
+                          querying metrics.
+                        type: string
                     type: object
                 type: object
             required:

--- a/ihpa-controller/config/crd/bases/ihpa.ake.cyberagent.co.jp_fittingjobs.yaml
+++ b/ihpa-controller/config/crd/bases/ihpa.ake.cyberagent.co.jp_fittingjobs.yaml
@@ -224,6 +224,15 @@ spec:
                   prometheus:
                     description: PrometheusProviderSource defines parameters for accessing
                       Prometheus.
+                    properties:
+                      pushgatewayUrl:
+                        description: PushgatewayURL is the address of the Prometheus
+                          Pushgateway for sending metrics.
+                        type: string
+                      url:
+                        description: URL is the address of the Prometheus server for
+                          querying metrics.
+                        type: string
                     type: object
                 type: object
               seasonality:
@@ -7843,6 +7852,15 @@ spec:
                   prometheus:
                     description: PrometheusProviderSource defines parameters for accessing
                       Prometheus.
+                    properties:
+                      pushgatewayUrl:
+                        description: PushgatewayURL is the address of the Prometheus
+                          Pushgateway for sending metrics.
+                        type: string
+                      url:
+                        description: URL is the address of the Prometheus server for
+                          querying metrics.
+                        type: string
                     type: object
                 type: object
               resources:

--- a/ihpa-controller/config/crd/bases/ihpa.ake.cyberagent.co.jp_intelligenthorizontalpodautoscalers.yaml
+++ b/ihpa-controller/config/crd/bases/ihpa.ake.cyberagent.co.jp_intelligenthorizontalpodautoscalers.yaml
@@ -212,6 +212,15 @@ spec:
                   prometheus:
                     description: PrometheusProviderSource defines parameters for accessing
                       Prometheus.
+                    properties:
+                      pushgatewayUrl:
+                        description: PushgatewayURL is the address of the Prometheus
+                          Pushgateway for sending metrics.
+                        type: string
+                      url:
+                        description: URL is the address of the Prometheus server for
+                          querying metrics.
+                        type: string
                     type: object
                 type: object
               template:
@@ -820,6 +829,15 @@ spec:
                   prometheus:
                     description: PrometheusProviderSource defines parameters for accessing
                       Prometheus.
+                    properties:
+                      pushgatewayUrl:
+                        description: PushgatewayURL is the address of the Prometheus
+                          Pushgateway for sending metrics.
+                        type: string
+                      url:
+                        description: URL is the address of the Prometheus server for
+                          querying metrics.
+                        type: string
                     type: object
                 type: object
               template:

--- a/ihpa-controller/controllers/metricprovider/config/config.go
+++ b/ihpa-controller/controllers/metricprovider/config/config.go
@@ -23,7 +23,10 @@ func ConvertMetricProvider(mp *ihpav1beta2.MetricProvider) *MetricProviderConfig
 		}
 		metricProvider.Datadog = &datadog
 	} else if mp.ProviderSource.Prometheus != nil {
-		prometheus := prometheusmp.Prometheus{}
+		prometheus := prometheusmp.Prometheus{
+			URL:           mp.ProviderSource.Prometheus.URL,
+			PushgatewayURL: mp.ProviderSource.Prometheus.PushgatewayURL,
+		}
 		metricProvider.Prometheus = &prometheus
 	}
 	return &metricProvider

--- a/ihpa-controller/controllers/metricprovider/config/config_test.go
+++ b/ihpa-controller/controllers/metricprovider/config/config_test.go
@@ -29,11 +29,17 @@ func TestConvertMetricProvider(t *testing.T) {
 			input: &ihpav1beta2.MetricProvider{
 				Name: "prometheus",
 				ProviderSource: ihpav1beta2.ProviderSource{
-					Prometheus: &ihpav1beta2.PrometheusProviderSource{},
+					Prometheus: &ihpav1beta2.PrometheusProviderSource{
+						URL:            "http://prometheus:9090",
+						PushgatewayURL: "http://pushgateway:9091",
+					},
 				},
 			},
 			expected: &MetricProviderConfig{
-				Prometheus: &prometheusmp.Prometheus{},
+				Prometheus: &prometheusmp.Prometheus{
+					URL:            "http://prometheus:9090",
+					PushgatewayURL: "http://pushgateway:9091",
+				},
 			},
 		},
 	}

--- a/ihpa-controller/controllers/metricprovider/prometheus/prometheus.go
+++ b/ihpa-controller/controllers/metricprovider/prometheus/prometheus.go
@@ -1,11 +1,31 @@
 package prometheus
 
-import "github.com/cyberagent-oss/intelligent-hpa/ihpa-controller/controllers/metricprovider"
+import (
+	"encoding/json"
+	"fmt"
+	"io/ioutil"
+	"net/http"
+	"net/url"
+	"strconv"
+	"strings"
+
+	"github.com/cyberagent-oss/intelligent-hpa/ihpa-controller/controllers/metricprovider"
+)
+
+const (
+	// QueryPath is the Prometheus query API endpoint.
+	QueryPath = "/api/v1/query"
+	// PushPath is the Pushgateway metrics endpoint.
+	PushPath = "/metrics"
+)
 
 var (
-	resourceMetricMap = map[string]metricIdentifier{}
-	objectMetricMap   = map[string]metricIdentifier{}
-	podsMetricMap     = map[string]metricIdentifier{}
+	resourceMetricMap = map[string]metricIdentifier{
+		"cpu":    {name: "container_cpu_usage_seconds_total", scale: -9},
+		"memory": {name: "container_memory_working_set_bytes", scale: 0},
+	}
+	objectMetricMap = map[string]metricIdentifier{}
+	podsMetricMap   = map[string]metricIdentifier{}
 )
 
 type metricIdentifier struct {
@@ -16,16 +36,134 @@ type metricIdentifier struct {
 func (mi *metricIdentifier) GetName() string { return mi.name }
 func (mi *metricIdentifier) GetScale() int   { return mi.scale }
 
-type Prometheus struct{}
+// Prometheus implements the MetricProvider interface for Prometheus.
+type Prometheus struct {
+	URL            string `json:"url"`
+	PushgatewayURL string `json:"pushgatewayUrl"`
+}
 
+type queryResponse struct {
+	Status string `json:"status"`
+	Data   queryData `json:"data"`
+}
+
+type queryData struct {
+	ResultType string        `json:"resultType"`
+	Result     []queryResult `json:"result"`
+}
+
+type queryResult struct {
+	Metric map[string]string `json:"metric"`
+	Value  []interface{}     `json:"value"`
+}
+
+// Send sends a metric to Prometheus via Pushgateway.
 func (p *Prometheus) Send(metricName string, timestamp int64, point float64, tags []string, opts map[string]interface{}) error {
+	if p.PushgatewayURL == "" {
+		return fmt.Errorf("pushgatewayURL is not configured")
+	}
+
+	// Build the Pushgateway URL with job label
+	pushURL := strings.TrimSuffix(p.PushgatewayURL, "/") + PushPath + "/job/estimator"
+
+	// Build the metric body in Prometheus text format
+	// Format: metric_name{tag1="value1",tag2="value2"} value timestamp
+	labels := strings.Join(tags, ",")
+	body := fmt.Sprintf("%s{%s} %f %d\n", metricName, labels, point, timestamp)
+
+	req, err := http.NewRequest(http.MethodPost, pushURL, strings.NewReader(body))
+	if err != nil {
+		return err
+	}
+	req.Header.Set("Content-Type", "text/plain; version=0.0.4; charset=utf-8")
+
+	resp, err := http.DefaultClient.Do(req)
+	if err != nil {
+		return err
+	}
+	defer resp.Body.Close()
+	if resp.StatusCode != http.StatusOK && resp.StatusCode != http.StatusAccepted {
+		b, err := ioutil.ReadAll(resp.Body)
+		if err != nil {
+			return err
+		}
+		return fmt.Errorf("pushgateway request error: %s (code=%d)", string(b), resp.StatusCode)
+	}
+
 	return nil
 }
 
+// Fetch queries a metric from Prometheus at the specified timestamp.
 func (p *Prometheus) Fetch(metricName string, timestamp int64, tags []string, opts map[string]interface{}) (float64, error) {
-	return 0.0, nil
+	if p.URL == "" {
+		return 0.0, fmt.Errorf("prometheus URL is not configured")
+	}
+
+	// Build the PromQL query: metric_name{tag1="value1",tag2="value2"}
+	query := metricName
+	if len(tags) > 0 {
+		query = fmt.Sprintf("%s{%s}", metricName, strings.Join(tags, ","))
+	}
+
+	params := url.Values{}
+	params.Set("query", query)
+	params.Set("time", fmt.Sprintf("%d", timestamp))
+
+	reqURL := strings.TrimSuffix(p.URL, "/") + QueryPath + "?" + params.Encode()
+
+	req, err := http.NewRequest(http.MethodGet, reqURL, nil)
+	if err != nil {
+		return 0.0, err
+	}
+
+	resp, err := http.DefaultClient.Do(req)
+	if err != nil {
+		return 0.0, err
+	}
+	defer resp.Body.Close()
+	if resp.StatusCode != http.StatusOK {
+		b, err := ioutil.ReadAll(resp.Body)
+		if err != nil {
+			return 0.0, err
+		}
+		return 0.0, fmt.Errorf("prometheus query error: %s (code=%d)", string(b), resp.StatusCode)
+	}
+
+	var qr queryResponse
+	if err := json.NewDecoder(resp.Body).Decode(&qr); err != nil {
+		return 0.0, fmt.Errorf("failed to decode response: %w", err)
+	}
+
+	if qr.Status != "success" {
+		return 0.0, fmt.Errorf("prometheus query returned status: %s", qr.Status)
+	}
+
+	if len(qr.Data.Result) == 0 {
+		return 0.0, nil
+	}
+
+	// Sum up all series values
+	var total float64
+	for _, r := range qr.Data.Result {
+		if len(r.Value) < 2 {
+			continue
+		}
+		switch v := r.Value[1].(type) {
+		case float64:
+			total += v
+		case string:
+			f, err := strconv.ParseFloat(v, 64)
+			if err != nil {
+				continue
+			}
+			total += f
+		}
+	}
+
+	return total, nil
 }
 
+// ConvertResourceMetricName converts a resource metric name to Prometheus-specific name.
 func (p *Prometheus) ConvertResourceMetricName(metricName string, reverse bool) metricprovider.MetricIdentifier {
 	if !reverse {
 		if v, ok := resourceMetricMap[metricName]; ok {
@@ -41,6 +179,7 @@ func (p *Prometheus) ConvertResourceMetricName(metricName string, reverse bool) 
 	return nil
 }
 
+// ConvertObjectMetricName converts an object metric name to Prometheus-specific name.
 func (p *Prometheus) ConvertObjectMetricName(metricName string, reverse bool) metricprovider.MetricIdentifier {
 	if !reverse {
 		if v, ok := objectMetricMap[metricName]; ok {
@@ -56,6 +195,7 @@ func (p *Prometheus) ConvertObjectMetricName(metricName string, reverse bool) me
 	return nil
 }
 
+// ConvertPodsMetricName converts a pods metric name to Prometheus-specific name.
 func (p *Prometheus) ConvertPodsMetricName(metricName string, reverse bool) metricprovider.MetricIdentifier {
 	if !reverse {
 		if v, ok := podsMetricMap[metricName]; ok {
@@ -71,6 +211,7 @@ func (p *Prometheus) ConvertPodsMetricName(metricName string, reverse bool) metr
 	return nil
 }
 
+// AddSumAggregator wraps the metric name with sum() for Prometheus queries.
 func (p *Prometheus) AddSumAggregator(metricName string) string {
-	return metricName
+	return fmt.Sprintf("sum(%s)", metricName)
 }

--- a/ihpa-controller/controllers/metricprovider/prometheus/prometheus_test.go
+++ b/ihpa-controller/controllers/metricprovider/prometheus/prometheus_test.go
@@ -1,0 +1,256 @@
+package prometheus
+
+import (
+	"encoding/json"
+	"net/http"
+	"net/http/httptest"
+	"reflect"
+	"testing"
+)
+
+func TestPrometheusSend(t *testing.T) {
+	var receivedBody string
+	var receivedPath string
+
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		receivedPath = r.URL.Path
+		body := make([]byte, 1024)
+		n, _ := r.Body.Read(body)
+		receivedBody = string(body[:n])
+		w.WriteHeader(http.StatusOK)
+	}))
+	defer server.Close()
+
+	p := &Prometheus{
+		URL:            "http://prometheus:9090",
+		PushgatewayURL: server.URL,
+	}
+
+	err := p.Send("ihpa.test.metric", 1609459200, 42.5, []string{"tag1:value1", "tag2:value2"}, nil)
+	if err != nil {
+		t.Fatalf("Send failed: %v", err)
+	}
+
+	if receivedPath != "/metrics/job/estimator" {
+		t.Fatalf("unexpected path: got=%s, exp=/metrics/job/estimator", receivedPath)
+	}
+
+	expectedBody := `ihpa.test.metric{tag1:value1,tag2:value2} 42.500000 1609459200` + "\n"
+	if receivedBody != expectedBody {
+		t.Fatalf("unexpected body: got=%q, exp=%q", receivedBody, expectedBody)
+	}
+}
+
+func TestPrometheusSendNoPushgatewayURL(t *testing.T) {
+	p := &Prometheus{
+		URL: "http://prometheus:9090",
+	}
+
+	err := p.Send("ihpa.test.metric", 1609459200, 42.5, []string{"tag1:value1"}, nil)
+	if err == nil {
+		t.Fatal("expected error when pushgatewayURL is not configured")
+	}
+}
+
+func TestPrometheusSendError(t *testing.T) {
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.WriteHeader(http.StatusInternalServerError)
+		w.Write([]byte("internal server error"))
+	}))
+	defer server.Close()
+
+	p := &Prometheus{
+		PushgatewayURL: server.URL,
+	}
+
+	err := p.Send("ihpa.test.metric", 1609459200, 42.5, []string{"tag1:value1"}, nil)
+	if err == nil {
+		t.Fatal("expected error on server error response")
+	}
+}
+
+func TestPrometheusFetch(t *testing.T) {
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.URL.Path != "/api/v1/query" {
+			t.Fatalf("unexpected path: got=%s, exp=/api/v1/query", r.URL.Path)
+		}
+
+		query := r.URL.Query().Get("query")
+		expectedQuery := `container_cpu_usage_seconds_total{host:server1}`
+		if query != expectedQuery {
+			t.Fatalf("unexpected query: got=%s, exp=%s", query, expectedQuery)
+		}
+
+		timeParam := r.URL.Query().Get("time")
+		if timeParam != "1609459200" {
+			t.Fatalf("unexpected time: got=%s, exp=1609459200", timeParam)
+		}
+
+		resp := queryResponse{
+			Status: "success",
+			Data: queryData{
+				ResultType: "vector",
+				Result: []queryResult{
+					{
+						Metric: map[string]string{"host": "server1"},
+						Value:  []interface{}{1609459200, "42.5"},
+					},
+					{
+						Metric: map[string]string{"host": "server2"},
+						Value:  []interface{}{1609459200, "10.0"},
+					},
+				},
+			},
+		}
+		json.NewEncoder(w).Encode(resp)
+	}))
+	defer server.Close()
+
+	p := &Prometheus{
+		URL: server.URL,
+	}
+
+	val, err := p.Fetch("container_cpu_usage_seconds_total", 1609459200, []string{"host:server1"}, nil)
+	if err != nil {
+		t.Fatalf("Fetch failed: %v", err)
+	}
+
+	expected := 52.5
+	if val != expected {
+		t.Fatalf("unexpected value: got=%f, exp=%f", val, expected)
+	}
+}
+
+func TestPrometheusFetchNoURL(t *testing.T) {
+	p := &Prometheus{}
+
+	_, err := p.Fetch("metric", 1609459200, nil, nil)
+	if err == nil {
+		t.Fatal("expected error when URL is not configured")
+	}
+}
+
+func TestPrometheusFetchEmptyResult(t *testing.T) {
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		resp := queryResponse{
+			Status: "success",
+			Data: queryData{
+				ResultType: "vector",
+				Result:     []queryResult{},
+			},
+		}
+		json.NewEncoder(w).Encode(resp)
+	}))
+	defer server.Close()
+
+	p := &Prometheus{
+		URL: server.URL,
+	}
+
+	val, err := p.Fetch("metric", 1609459200, nil, nil)
+	if err != nil {
+		t.Fatalf("Fetch failed: %v", err)
+	}
+
+	if val != 0.0 {
+		t.Fatalf("unexpected value: got=%f, exp=0.0", val)
+	}
+}
+
+func TestPrometheusFetchError(t *testing.T) {
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.WriteHeader(http.StatusBadRequest)
+		w.Write([]byte("bad request"))
+	}))
+	defer server.Close()
+
+	p := &Prometheus{
+		URL: server.URL,
+	}
+
+	_, err := p.Fetch("metric", 1609459200, nil, nil)
+	if err == nil {
+		t.Fatal("expected error on server error response")
+	}
+}
+
+func TestPrometheusConvertResourceMetricName(t *testing.T) {
+	p := &Prometheus{}
+
+	tests := []struct {
+		metricName string
+		reverse    bool
+		expected   *metricIdentifier
+	}{
+		{
+			metricName: "cpu",
+			reverse:    false,
+			expected:   &metricIdentifier{name: "container_cpu_usage_seconds_total", scale: -9},
+		},
+		{
+			metricName: "memory",
+			reverse:    false,
+			expected:   &metricIdentifier{name: "container_memory_working_set_bytes", scale: 0},
+		},
+		{
+			metricName: "unknown",
+			reverse:    false,
+			expected:   nil,
+		},
+		{
+			metricName: "container_cpu_usage_seconds_total",
+			reverse:    true,
+			expected:   &metricIdentifier{name: "cpu", scale: -9},
+		},
+		{
+			metricName: "container_memory_working_set_bytes",
+			reverse:    true,
+			expected:   &metricIdentifier{name: "memory", scale: 0},
+		},
+		{
+			metricName: "unknown",
+			reverse:    true,
+			expected:   nil,
+		},
+	}
+
+	for _, tt := range tests {
+		got := p.ConvertResourceMetricName(tt.metricName, tt.reverse)
+		if tt.expected == nil {
+			if got != nil {
+				t.Fatalf("ConvertResourceMetricName(%q, %v) = %#v, expected nil", tt.metricName, tt.reverse, got)
+			}
+		} else {
+			if got == nil {
+				t.Fatalf("ConvertResourceMetricName(%q, %v) = nil, expected %#v", tt.metricName, tt.reverse, tt.expected)
+			} else if !reflect.DeepEqual(*got.(*metricIdentifier), *tt.expected) {
+				t.Fatalf("ConvertResourceMetricName(%q, %v) = %#v, expected %#v", tt.metricName, tt.reverse, got, tt.expected)
+			}
+		}
+	}
+}
+
+func TestPrometheusAddSumAggregator(t *testing.T) {
+	p := &Prometheus{}
+
+	tests := []struct {
+		metricName string
+		expected   string
+	}{
+		{
+			metricName: "container_cpu_usage_seconds_total",
+			expected:   "sum(container_cpu_usage_seconds_total)",
+		},
+		{
+			metricName: "ihpa.test.metric",
+			expected:   "sum(ihpa.test.metric)",
+		},
+	}
+
+	for _, tt := range tests {
+		got := p.AddSumAggregator(tt.metricName)
+		if got != tt.expected {
+			t.Fatalf("AddSumAggregator(%q) = %q, expected %q", tt.metricName, got, tt.expected)
+		}
+	}
+}

--- a/manifests/intelligent-hpa.yaml
+++ b/manifests/intelligent-hpa.yaml
@@ -138,6 +138,15 @@ spec:
                   prometheus:
                     description: PrometheusProviderSource defines parameters for accessing
                       Prometheus.
+                    properties:
+                      pushgatewayUrl:
+                        description: PushgatewayURL is the address of the Prometheus
+                          Pushgateway for sending metrics.
+                        type: string
+                      url:
+                        description: URL is the address of the Prometheus server for
+                          querying metrics.
+                        type: string
                     type: object
                 type: object
             required:
@@ -385,6 +394,15 @@ spec:
                   prometheus:
                     description: PrometheusProviderSource defines parameters for accessing
                       Prometheus.
+                    properties:
+                      pushgatewayUrl:
+                        description: PushgatewayURL is the address of the Prometheus
+                          Pushgateway for sending metrics.
+                        type: string
+                      url:
+                        description: URL is the address of the Prometheus server for
+                          querying metrics.
+                        type: string
                     type: object
                 type: object
               seasonality:
@@ -8007,6 +8025,15 @@ spec:
                   prometheus:
                     description: PrometheusProviderSource defines parameters for accessing
                       Prometheus.
+                    properties:
+                      pushgatewayUrl:
+                        description: PushgatewayURL is the address of the Prometheus
+                          Pushgateway for sending metrics.
+                        type: string
+                      url:
+                        description: URL is the address of the Prometheus server for
+                          querying metrics.
+                        type: string
                     type: object
                 type: object
               resources:
@@ -9521,6 +9548,15 @@ spec:
                   prometheus:
                     description: PrometheusProviderSource defines parameters for accessing
                       Prometheus.
+                    properties:
+                      pushgatewayUrl:
+                        description: PushgatewayURL is the address of the Prometheus
+                          Pushgateway for sending metrics.
+                        type: string
+                      url:
+                        description: URL is the address of the Prometheus server for
+                          querying metrics.
+                        type: string
                     type: object
                 type: object
               template:
@@ -10129,6 +10165,15 @@ spec:
                   prometheus:
                     description: PrometheusProviderSource defines parameters for accessing
                       Prometheus.
+                    properties:
+                      pushgatewayUrl:
+                        description: PushgatewayURL is the address of the Prometheus
+                          Pushgateway for sending metrics.
+                        type: string
+                      url:
+                        description: URL is the address of the Prometheus server for
+                          querying metrics.
+                        type: string
                     type: object
                 type: object
               template:


### PR DESCRIPTION
## 概要

Issue #14 の対応です。

Prometheusメトリクスプロバイダーの完全な実装を追加しました。従来はスタブ（no-op）実装でしたが、実際のPrometheus/Pushgateway APIと通信する実装に置き換えました。

## 変更内容

### CRD型の拡張
- `v1beta1` / `v1beta2` の `PrometheusProviderSource` に `URL` と `PushgatewayURL` フィールドを追加

### Prometheus プロバイダー実装 (`prometheus.go`)
- **`Send()`**: Pushgateway経由でメトリクスを送信（Prometheus text format）
- **`Fetch()`**: Prometheus API (`/api/v1/query`) からメトリクスをクエリし、複数シリーズの合計値を返す
- **`resourceMetricMap`**: `cpu` → `container_cpu_usage_seconds_total`, `memory` → `container_memory_working_set_bytes` を定義
- **`AddSumAggregator()`**: PromQLの `sum()` でラップ（Datadogの `sum:` プレフィックスに相当）
- `ConvertResourceMetricName`, `ConvertObjectMetricName`, `ConvertPodsMetricName` は既存のまま

### 設定フロー
- `config.go`: `ConvertMetricProvider` で `URL` / `PushgatewayURL` をプロバイダーに渡すよう更新

### テスト
- `prometheus_test.go`: Send/Fetch/ConvertResourceMetricName/AddSumAggregator の包括的テストを追加
- `config_test.go`: Prometheus URLフィールドの変換テストを更新

### マニフェスト・ドキュメント
- CRD YAML（estimators, fittingjobs, intelligenthorizontalpodautoscalers, manifests/intelligent-hpa.yaml）に `url` / `pushgatewayUrl` プロパティを追加
- README.md / README-jp.md にPrometheus設定例を追加

## テスト結果

```
=== RUN   TestConvertMetricProvider
--- PASS: TestConvertMetricProvider (0.00s)
=== RUN   TestPrometheusSend
--- PASS: TestPrometheusSend (0.00s)
=== RUN   TestPrometheusSendNoPushgatewayURL
--- PASS: TestPrometheusSendNoPushgatewayURL (0.00s)
=== RUN   TestPrometheusSendError
--- PASS: TestPrometheusSendError (0.00s)
=== RUN   TestPrometheusFetch
--- PASS: TestPrometheusFetch (0.00s)
=== RUN   TestPrometheusFetchNoURL
--- PASS: TestPrometheusFetchNoURL (0.00s)
=== RUN   TestPrometheusFetchEmptyResult
--- PASS: TestPrometheusFetchEmptyResult (0.00s)
=== RUN   TestPrometheusFetchError
--- PASS: TestPrometheusFetchError (0.00s)
=== RUN   TestPrometheusConvertResourceMetricName
--- PASS: TestPrometheusConvertResourceMetricName (0.00s)
=== RUN   TestPrometheusAddSumAggregator
--- PASS: TestPrometheusAddSumAggregator (0.00s)
PASS
```

## 関連Issue

Closes #14