### PR TITLE
feat: resolve Datadog keys from Secret/ConfigMap via keysFrom

### DIFF
--- a/README-jp.md
+++ b/README-jp.md
@@ -126,6 +126,11 @@ spec:
     datadog:
       apikey: xxx
       appkey: yyy
+      # SecretまたはConfigMapからキーを参照することも可能です:
+      # keysFrom:
+      #   - secretRef:
+      #       name: datadog-keys
+      # Secret/ConfigMapには "APIKey" と "APPKey" というキーを含める必要があります
   template:
     spec:
       scaleTargetRef:

--- a/README.md
+++ b/README.md
@@ -127,6 +127,11 @@ spec:
     datadog:
       apikey: xxx
       appkey: yyy
+      # Alternatively, you can reference keys from a Secret or ConfigMap:
+      # keysFrom:
+      #   - secretRef:
+      #       name: datadog-keys
+      # The Secret/ConfigMap must contain keys named "APIKey" and "APPKey".
   template:
     spec:
       scaleTargetRef:

--- a/ihpa-controller/controllers/intelligenthorizontalpodautoscaler_controller.go
+++ b/ihpa-controller/controllers/intelligenthorizontalpodautoscaler_controller.go
@@ -73,11 +73,6 @@ func (r *IntelligentHorizontalPodAutoscalerReconciler) Reconcile(req ctrl.Reques
 	log := r.Log.WithValues("intelligenthorizontalpodautoscaler", req.NamespacedName)
 	ihpaNamespacedName := req.NamespacedName.String()
 
-	// TODO: (low) fetch datadog key from env
-	// TODO: (low) determine sum/min/max/count/avg from IHPA property
-	// TODO: (low) consider selector of hpa object type
-	// TODO: (low) write any status to configmap
-
 	var ihpa ihpav1beta2.IntelligentHorizontalPodAutoscaler
 	if err := r.Get(ctx, req.NamespacedName, &ihpa); err != nil {
 		log.V(ResourceMessageLogLevel).Info("failed to fetch IntelligentHorizontalPodAutoscaler", "error_message", err)

--- a/ihpa-controller/controllers/intelligenthorizontalpodautoscaler_generator_impl.go
+++ b/ihpa-controller/controllers/intelligenthorizontalpodautoscaler_generator_impl.go
@@ -18,6 +18,7 @@ import (
 	"k8s.io/apimachinery/pkg/api/resource"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	amtypes "k8s.io/apimachinery/pkg/types"
+	"sigs.k8s.io/controller-runtime/pkg/client"
 )
 
 type ihpaGeneratorImpl struct {
@@ -63,7 +64,52 @@ func NewIntelligentHorizontalPodAutoscalerGenerator(
 	}
 	rl := *totalResourceList(containers)
 
+	// Resolve Datadog API/APP keys from Secrets/ConfigMaps if KeysFrom is specified
+	if ihpa.Spec.MetricProvider.ProviderSource.Datadog != nil && len(ihpa.Spec.MetricProvider.ProviderSource.Datadog.KeysFrom) > 0 {
+		if err := resolveDatadogKeysFromEnv(ctx, r, ihpa.GetNamespace(), ihpa.Spec.MetricProvider.ProviderSource.Datadog); err != nil {
+			return nil, fmt.Errorf("failed to resolve datadog keys from env: %w", err)
+		}
+	}
+
 	return &ihpaGeneratorImpl{ihpa: ihpa, scaleTargetRequests: rl, kubeSystemUID: string(kubeSystemNS.GetUID())}, nil
+}
+
+// resolveDatadogKeysFromEnv resolves APIKey and APPKey from Secrets or ConfigMaps
+// specified in KeysFrom. It searches for keys named "APIKey" and "APPKey".
+func resolveDatadogKeysFromEnv(ctx context.Context, r client.Client, namespace string, datadog *ihpav1beta2.DatadogProviderSource) error {
+	for _, envFrom := range datadog.KeysFrom {
+		if envFrom.SecretRef != nil {
+			secret := &corev1.Secret{}
+			if err := r.Get(ctx, amtypes.NamespacedName{Namespace: namespace, Name: envFrom.SecretRef.Name}, secret); err != nil {
+				if envFrom.SecretRef.Optional != nil && *envFrom.SecretRef.Optional {
+					continue
+				}
+				return fmt.Errorf("failed to get secret %s: %w", envFrom.SecretRef.Name, err)
+			}
+			if apiKey, ok := secret.Data["APIKey"]; ok {
+				datadog.APIKey = string(apiKey)
+			}
+			if appKey, ok := secret.Data["APPKey"]; ok {
+				datadog.APPKey = string(appKey)
+			}
+		}
+		if envFrom.ConfigMapRef != nil {
+			cm := &corev1.ConfigMap{}
+			if err := r.Get(ctx, amtypes.NamespacedName{Namespace: namespace, Name: envFrom.ConfigMapRef.Name}, cm); err != nil {
+				if envFrom.ConfigMapRef.Optional != nil && *envFrom.ConfigMapRef.Optional {
+					continue
+				}
+				return fmt.Errorf("failed to get configmap %s: %w", envFrom.ConfigMapRef.Name, err)
+			}
+			if apiKey, ok := cm.Data["APIKey"]; ok {
+				datadog.APIKey = apiKey
+			}
+			if appKey, ok := cm.Data["APPKey"]; ok {
+				datadog.APPKey = appKey
+			}
+		}
+	}
+	return nil
 }
 
 // HorizontalPodAutoscalerResource returns an HPA resource which forecasted metrics is added to.

--- a/ihpa-controller/controllers/intelligenthorizontalpodautoscaler_generator_impl_test.go
+++ b/ihpa-controller/controllers/intelligenthorizontalpodautoscaler_generator_impl_test.go
@@ -1,6 +1,7 @@
 package controllers
 
 import (
+	"context"
 	"fmt"
 	"reflect"
 	"testing"
@@ -11,6 +12,8 @@ import (
 	rbacv1 "k8s.io/api/rbac/v1"
 	"k8s.io/apimachinery/pkg/api/resource"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/runtime"
+	"sigs.k8s.io/controller-runtime/pkg/client/fake"
 )
 
 func testIHPAGeneratorSample(t *testing.T) (*ihpaGeneratorImpl, *ihpaGeneratorImpl) {
@@ -1560,5 +1563,191 @@ func TestIhpaString(t *testing.T) {
 		if got != tt.expected {
 			t.Fatalf("ihpaString is not match (got=%s, exp=%s)", got, tt.expected)
 		}
+	}
+}
+
+func TestResolveDatadogKeysFromEnv(t *testing.T) {
+	tests := []struct {
+		name        string
+		namespace   string
+		datadog     *ihpav1beta2.DatadogProviderSource
+		secrets     []runtime.Object
+		configMaps  []runtime.Object
+		expectAPI   string
+		expectAPP   string
+		expectError bool
+	}{
+		{
+			name:      "resolve keys from secret",
+			namespace: "default",
+			datadog: &ihpav1beta2.DatadogProviderSource{
+				KeysFrom: []corev1.EnvFromSource{
+					{
+						SecretRef: &corev1.SecretEnvSource{
+							LocalObjectReference: corev1.LocalObjectReference{Name: "datadog-keys"},
+						},
+					},
+				},
+			},
+			secrets: []runtime.Object{
+				&corev1.Secret{
+					ObjectMeta: metav1.ObjectMeta{Name: "datadog-keys", Namespace: "default"},
+					Data: map[string][]byte{
+						"APIKey": []byte("secret-api-key"),
+						"APPKey": []byte("secret-app-key"),
+					},
+				},
+			},
+			expectAPI: "secret-api-key",
+			expectAPP: "secret-app-key",
+		},
+		{
+			name:      "resolve keys from configmap",
+			namespace: "default",
+			datadog: &ihpav1beta2.DatadogProviderSource{
+				KeysFrom: []corev1.EnvFromSource{
+					{
+						ConfigMapRef: &corev1.ConfigMapEnvSource{
+							LocalObjectReference: corev1.LocalObjectReference{Name: "datadog-keys-cm"},
+						},
+					},
+				},
+			},
+			configMaps: []runtime.Object{
+				&corev1.ConfigMap{
+					ObjectMeta: metav1.ObjectMeta{Name: "datadog-keys-cm", Namespace: "default"},
+					Data: map[string]string{
+						"APIKey": "cm-api-key",
+						"APPKey": "cm-app-key",
+					},
+				},
+			},
+			expectAPI: "cm-api-key",
+			expectAPP: "cm-app-key",
+		},
+		{
+			name:      "resolve keys from secret with prefix",
+			namespace: "default",
+			datadog: &ihpav1beta2.DatadogProviderSource{
+				KeysFrom: []corev1.EnvFromSource{
+					{
+						SecretRef: &corev1.SecretEnvSource{
+							LocalObjectReference: corev1.LocalObjectReference{Name: "dd-keys"},
+						},
+					},
+				},
+			},
+			secrets: []runtime.Object{
+				&corev1.Secret{
+					ObjectMeta: metav1.ObjectMeta{Name: "dd-keys", Namespace: "default"},
+					Data: map[string][]byte{
+						"APIKey": []byte("api-from-secret"),
+					},
+				},
+			},
+			expectAPI: "api-from-secret",
+			expectAPP: "",
+		},
+		{
+			name:      "optional secret not found is skipped",
+			namespace: "default",
+			datadog: &ihpav1beta2.DatadogProviderSource{
+				KeysFrom: []corev1.EnvFromSource{
+					{
+						SecretRef: &corev1.SecretEnvSource{
+							LocalObjectReference: corev1.LocalObjectReference{Name: "nonexistent"},
+							Optional:             func(b bool) *bool { return &b }(true),
+						},
+					},
+				},
+			},
+			expectAPI: "",
+			expectAPP: "",
+		},
+		{
+			name:      "required secret not found returns error",
+			namespace: "default",
+			datadog: &ihpav1beta2.DatadogProviderSource{
+				KeysFrom: []corev1.EnvFromSource{
+					{
+						SecretRef: &corev1.SecretEnvSource{
+							LocalObjectReference: corev1.LocalObjectReference{Name: "nonexistent"},
+						},
+					},
+				},
+			},
+			expectError: true,
+		},
+		{
+			name:      "multiple sources - secret overrides configmap",
+			namespace: "default",
+			datadog: &ihpav1beta2.DatadogProviderSource{
+				KeysFrom: []corev1.EnvFromSource{
+					{
+						ConfigMapRef: &corev1.ConfigMapEnvSource{
+							LocalObjectReference: corev1.LocalObjectReference{Name: "cm-keys"},
+						},
+					},
+					{
+						SecretRef: &corev1.SecretEnvSource{
+							LocalObjectReference: corev1.LocalObjectReference{Name: "secret-keys"},
+						},
+					},
+				},
+			},
+			secrets: []runtime.Object{
+				&corev1.Secret{
+					ObjectMeta: metav1.ObjectMeta{Name: "secret-keys", Namespace: "default"},
+					Data: map[string][]byte{
+						"APIKey": []byte("final-api-key"),
+						"APPKey": []byte("final-app-key"),
+					},
+				},
+			},
+			configMaps: []runtime.Object{
+				&corev1.ConfigMap{
+					ObjectMeta: metav1.ObjectMeta{Name: "cm-keys", Namespace: "default"},
+					Data: map[string]string{
+						"APIKey": "initial-api-key",
+						"APPKey": "initial-app-key",
+					},
+				},
+			},
+			expectAPI: "final-api-key",
+			expectAPP: "final-app-key",
+		},
+		{
+			name:      "no keysFrom - no change",
+			namespace: "default",
+			datadog: &ihpav1beta2.DatadogProviderSource{
+				APIKey: "original-api",
+				APPKey: "original-app",
+			},
+			expectAPI: "original-api",
+			expectAPP: "original-app",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			objs := append(tt.secrets, tt.configMaps...)
+			c := fake.NewFakeClient(objs...)
+			err := resolveDatadogKeysFromEnv(context.Background(), c, tt.namespace, tt.datadog)
+			if tt.expectError {
+				if err == nil {
+					t.Fatal("expected error but got nil")
+				}
+				return
+			}
+			if err != nil {
+				t.Fatalf("unexpected error: %v", err)
+			}
+			if tt.datadog.APIKey != tt.expectAPI {
+				t.Fatalf("APIKey mismatch: got=%s, exp=%s", tt.datadog.APIKey, tt.expectAPI)
+			}
+			if tt.datadog.APPKey != tt.expectAPP {
+				t.Fatalf("APPKey mismatch: got=%s, exp=%s", tt.datadog.APPKey, tt.expectAPP)
+			}
+		})
 	}
 }


### PR DESCRIPTION
## 概要

Issue #16 の対応です。

従来、DatadogのAPI/APPキーはIHPAマニフェストに平文で記述する必要がありました。本PRでは、CRDに定義済みだった `keysFrom` フィールドを実装し、Kubernetes SecretまたはConfigMapからキーを取得できるようにします。

## 変更内容

### 実装
- `resolveDatadogKeysFromEnv()` 関数を追加: `keysFrom` に指定されたSecret/ConfigMapから `APIKey` / `APPKey` を取得
  - Secretの `Data` フィールド、ConfigMapの `Data` フィールドから検索
  - `optional` フラグがtrueの場合は見つからなくてもエラーにしない
  - 複数のソースを指定可能（後のソースが前のソースを上書き）
- ジェネレーター初期化時に `resolveDatadogKeysFromEnv()` を呼び出し
- `intelligenthorizontalpodautoscaler_controller.go` の `TODO: fetch datadog key from env` コメントを削除

### テスト
- `TestResolveDatadogKeysFromEnv` を追加:
  - Secretからのキー取得
  - ConfigMapからのキー取得
  - SecretにAPIKeyのみ存在するケース
  - optional指定時の見つからないケースのスキップ
  - 必須指定時の見つからないケースのエラー
  - 複数ソース（ConfigMap→Secretの上書き）
  - keysFrom未指定時の変更なし

### ドキュメント
- README.md / README-jp.md に `keysFrom` の使用例を追加

## 使用例

```yaml
metricProvider:
  name: datadog
  datadog:
    keysFrom:
      - secretRef:
          name: datadog-keys
```

Secretに `APIKey` と `APPKey` キーを含める必要があります:

```yaml
apiVersion: v1
kind: Secret
metadata:
  name: datadog-keys
type: Opaque
stringData:
  APIKey: your-api-key
  APPKey: your-app-key
```

## テスト結果

```
=== RUN   TestResolveDatadogKeysFromEnv
--- PASS: TestResolveDatadogKeysFromEnv (0.00s)
    --- PASS: TestResolveDatadogKeysFromEnv/resolve_keys_from_secret
    --- PASS: TestResolveDatadogKeysFromEnv/resolve_keys_from_configmap
    --- PASS: TestResolveDatadogKeysFromEnv/resolve_keys_from_secret_with_prefix
    --- PASS: TestResolveDatadogKeysFromEnv/optional_secret_not_found_is_skipped
    --- PASS: TestResolveDatadogKeysFromEnv/required_secret_not_found_returns_error
    --- PASS: TestResolveDatadogKeysFromEnv/multiple_sources_-_secret_overrides_configmap
    --- PASS: TestResolveDatadogKeysFromEnv/no_keysFrom_-_no_change
PASS
```

## 関連Issue

Closes #16