### PR TITLE
feat: support configurable aggregation function (sum/min/max/count/avg)

### DIFF
--- a/README-jp.md
+++ b/README-jp.md
@@ -77,6 +77,9 @@ Intelligent HPA のマニフェストについて説明します。
 - `metricProvider`
     - メトリクスを取得・送信するプロバイダを設定します
     - Datadog と Prometheus に対応しています
+    - `aggregation`
+        - メトリクスのクエリ時に使用する集計関数を指定します
+        - 許容値: `sum`, `min`, `max`, `count`, `avg` (default: `sum`)
 - `template`
     - HPA のマニフェストを記述します
     - HPA から移行する場合はそのままここにコピーしてください
@@ -123,6 +126,7 @@ spec:
     mode: adjust
   metricProvider:
     name: datadog
+    aggregation: sum
     datadog:
       apikey: xxx
       appkey: yyy

--- a/README.md
+++ b/README.md
@@ -79,6 +79,9 @@ IHPA manifest has some field below:
 - `metricProvider`
     - Provider for sending and fetching metrics
     - Datadog and Prometheus are supported
+    - `aggregation`
+        - Aggregation function used when querying metrics
+        - Allowable: `sum`, `min`, `max`, `count`, `avg` (default: `sum`)
 - `template`
     - Almost same template as HorizontalPodAutoscaler
     - You can copy/paste HPA manifests to this field
@@ -124,6 +127,7 @@ spec:
     mode: adjust
   metricProvider:
     name: datadog
+    aggregation: sum
     datadog:
       apikey: xxx
       appkey: yyy

--- a/ihpa-controller/api/v1beta1/intelligenthorizontalpodautoscaler_types.go
+++ b/ihpa-controller/api/v1beta1/intelligenthorizontalpodautoscaler_types.go
@@ -96,6 +96,12 @@ type MetricProvider struct {
 	// Name is a name of provider
 	Name string `json:"name,omitempty"`
 
+	// Aggregation is the aggregation function used when querying metrics.
+	// Valid values are: sum, min, max, count, avg.
+	// +kubebuilder:validation:Enum=sum;min;max;count;avg
+	// +kubebuilder:default=sum
+	Aggregation string `json:"aggregation,omitempty"`
+
 	// ProviderSource is source of metrics provider.
 	// This is defined as ***ProviderSource.
 	ProviderSource `json:",inline"`

--- a/ihpa-controller/api/v1beta2/intelligenthorizontalpodautoscaler_types.go
+++ b/ihpa-controller/api/v1beta2/intelligenthorizontalpodautoscaler_types.go
@@ -143,6 +143,12 @@ type MetricProvider struct {
 	// Name is a name of provider
 	Name string `json:"name,omitempty"`
 
+	// Aggregation is the aggregation function used when querying metrics.
+	// Valid values are: sum, min, max, count, avg.
+	// +kubebuilder:validation:Enum=sum;min;max;count;avg
+	// +kubebuilder:default=sum
+	Aggregation string `json:"aggregation,omitempty"`
+
 	// ProviderSource is source of metrics provider.
 	// This is defined as ***ProviderSource.
 	ProviderSource `json:",inline"`

--- a/ihpa-controller/config/crd/bases/ihpa.ake.cyberagent.co.jp_estimators.yaml
+++ b/ihpa-controller/config/crd/bases/ihpa.ake.cyberagent.co.jp_estimators.yaml
@@ -134,6 +134,16 @@ spec:
                   name:
                     description: Name is a name of provider
                     type: string
+                  aggregation:
+                    description: Aggregation is the aggregation function used when
+                      querying metrics. Valid values are: sum, min, max, count, avg.
+                    enum:
+                    - sum
+                    - min
+                    - max
+                    - count
+                    - avg
+                    type: string
                   prometheus:
                     description: PrometheusProviderSource defines parameters for accessing
                       Prometheus.

--- a/ihpa-controller/config/crd/bases/ihpa.ake.cyberagent.co.jp_fittingjobs.yaml
+++ b/ihpa-controller/config/crd/bases/ihpa.ake.cyberagent.co.jp_fittingjobs.yaml
@@ -221,6 +221,16 @@ spec:
                   name:
                     description: Name is a name of provider
                     type: string
+                  aggregation:
+                    description: Aggregation is the aggregation function used when
+                      querying metrics. Valid values are: sum, min, max, count, avg.
+                    enum:
+                    - sum
+                    - min
+                    - max
+                    - count
+                    - avg
+                    type: string
                   prometheus:
                     description: PrometheusProviderSource defines parameters for accessing
                       Prometheus.
@@ -7848,6 +7858,16 @@ spec:
                     type: object
                   name:
                     description: Name is a name of provider
+                    type: string
+                  aggregation:
+                    description: Aggregation is the aggregation function used when
+                      querying metrics. Valid values are: sum, min, max, count, avg.
+                    enum:
+                    - sum
+                    - min
+                    - max
+                    - count
+                    - avg
                     type: string
                   prometheus:
                     description: PrometheusProviderSource defines parameters for accessing

--- a/ihpa-controller/config/crd/bases/ihpa.ake.cyberagent.co.jp_intelligenthorizontalpodautoscalers.yaml
+++ b/ihpa-controller/config/crd/bases/ihpa.ake.cyberagent.co.jp_intelligenthorizontalpodautoscalers.yaml
@@ -209,6 +209,16 @@ spec:
                   name:
                     description: Name is a name of provider
                     type: string
+                  aggregation:
+                    description: Aggregation is the aggregation function used when
+                      querying metrics. Valid values are: sum, min, max, count, avg.
+                    enum:
+                    - sum
+                    - min
+                    - max
+                    - count
+                    - avg
+                    type: string
                   prometheus:
                     description: PrometheusProviderSource defines parameters for accessing
                       Prometheus.
@@ -825,6 +835,16 @@ spec:
                     type: object
                   name:
                     description: Name is a name of provider
+                    type: string
+                  aggregation:
+                    description: Aggregation is the aggregation function used when
+                      querying metrics. Valid values are: sum, min, max, count, avg.
+                    enum:
+                    - sum
+                    - min
+                    - max
+                    - count
+                    - avg
                     type: string
                   prometheus:
                     description: PrometheusProviderSource defines parameters for accessing

--- a/ihpa-controller/controllers/estimator.go
+++ b/ihpa-controller/controllers/estimator.go
@@ -247,7 +247,7 @@ estimatorLoop:
 					prevData = *d
 					var err error
 					prevY, err = et.MetricProvider.Fetch(
-						et.MetricProvider.AddSumAggregator(et.BaseMetricName),
+						et.MetricProvider.AddAggregator(et.BaseMetricName),
 						prevData.UnixTime,
 						et.BaseMetricTags,
 						nil,

--- a/ihpa-controller/controllers/fittingjob_generator_impl.go
+++ b/ihpa-controller/controllers/fittingjob_generator_impl.go
@@ -24,7 +24,7 @@ func (g *fittingJobGeneratorImpl) ConfigMapResource() (*corev1.ConfigMap, error)
 
 	fittingJobConfig := &FittingJobConfig{
 		MetricProvider:             *mpConfig,
-		TargetMetricsName:          mpConfig.ActiveProvider().AddSumAggregator(g.fj.Spec.TargetMetric.Name),
+		TargetMetricsName:          mpConfig.ActiveProvider().AddAggregator(g.fj.Spec.TargetMetric.Name),
 		TargetTags:                 g.fj.Spec.TargetMetric.Selector.MatchLabels,
 		Seasonality:                g.fj.Spec.Seasonality,
 		ChangePointDetectionConfig: g.fj.Spec.ChangePointDetectionConfig,

--- a/ihpa-controller/controllers/metricprovider/config/config.go
+++ b/ihpa-controller/controllers/metricprovider/config/config.go
@@ -18,14 +18,16 @@ func ConvertMetricProvider(mp *ihpav1beta2.MetricProvider) *MetricProviderConfig
 	metricProvider := MetricProviderConfig{}
 	if mp.ProviderSource.Datadog != nil {
 		datadog := datadogmp.Datadog{
-			APIKey: mp.ProviderSource.Datadog.APIKey,
-			APPKey: mp.ProviderSource.Datadog.APPKey,
+			APIKey:      mp.ProviderSource.Datadog.APIKey,
+			APPKey:      mp.ProviderSource.Datadog.APPKey,
+			Aggregation: mp.Aggregation,
 		}
 		metricProvider.Datadog = &datadog
 	} else if mp.ProviderSource.Prometheus != nil {
 		prometheus := prometheusmp.Prometheus{
-			URL:           mp.ProviderSource.Prometheus.URL,
+			URL:            mp.ProviderSource.Prometheus.URL,
 			PushgatewayURL: mp.ProviderSource.Prometheus.PushgatewayURL,
+			Aggregation:    mp.Aggregation,
 		}
 		metricProvider.Prometheus = &prometheus
 	}

--- a/ihpa-controller/controllers/metricprovider/config/config_test.go
+++ b/ihpa-controller/controllers/metricprovider/config/config_test.go
@@ -11,10 +11,12 @@ import (
 
 func TestConvertMetricProvider(t *testing.T) {
 	tests := []struct {
+		name     string
 		input    *ihpav1beta2.MetricProvider
 		expected *MetricProviderConfig
 	}{
 		{
+			name: "datadog without aggregation",
 			input: &ihpav1beta2.MetricProvider{
 				Name: "datadog",
 				ProviderSource: ihpav1beta2.ProviderSource{
@@ -26,6 +28,20 @@ func TestConvertMetricProvider(t *testing.T) {
 			},
 		},
 		{
+			name: "datadog with aggregation",
+			input: &ihpav1beta2.MetricProvider{
+				Name:        "datadog",
+				Aggregation: "avg",
+				ProviderSource: ihpav1beta2.ProviderSource{
+					Datadog: &ihpav1beta2.DatadogProviderSource{APIKey: "xxx", APPKey: "yyy"},
+				},
+			},
+			expected: &MetricProviderConfig{
+				Datadog: &datadogmp.Datadog{APIKey: "xxx", APPKey: "yyy", Aggregation: "avg"},
+			},
+		},
+		{
+			name: "prometheus without aggregation",
 			input: &ihpav1beta2.MetricProvider{
 				Name: "prometheus",
 				ProviderSource: ihpav1beta2.ProviderSource{
@@ -42,12 +58,34 @@ func TestConvertMetricProvider(t *testing.T) {
 				},
 			},
 		},
+		{
+			name: "prometheus with aggregation",
+			input: &ihpav1beta2.MetricProvider{
+				Name:        "prometheus",
+				Aggregation: "max",
+				ProviderSource: ihpav1beta2.ProviderSource{
+					Prometheus: &ihpav1beta2.PrometheusProviderSource{
+						URL:            "http://prometheus:9090",
+						PushgatewayURL: "http://pushgateway:9091",
+					},
+				},
+			},
+			expected: &MetricProviderConfig{
+				Prometheus: &prometheusmp.Prometheus{
+					URL:            "http://prometheus:9090",
+					PushgatewayURL: "http://pushgateway:9091",
+					Aggregation:    "max",
+				},
+			},
+		},
 	}
 
 	for _, tt := range tests {
-		got := ConvertMetricProvider(tt.input)
-		if !reflect.DeepEqual(got, tt.expected) {
-			t.Fatalf("metric provider is not match (got=%v, expected=%v)", got, tt.expected)
-		}
+		t.Run(tt.name, func(t *testing.T) {
+			got := ConvertMetricProvider(tt.input)
+			if !reflect.DeepEqual(got, tt.expected) {
+				t.Fatalf("metric provider is not match (got=%v, expected=%v)", got, tt.expected)
+			}
+		})
 	}
 }

--- a/ihpa-controller/controllers/metricprovider/datadog/datadog.go
+++ b/ihpa-controller/controllers/metricprovider/datadog/datadog.go
@@ -37,8 +37,9 @@ func (mi *metricIdentifier) GetName() string { return mi.name }
 func (mi *metricIdentifier) GetScale() int   { return mi.scale }
 
 type Datadog struct {
-	APIKey string `json:"apikey"`
-	APPKey string `json:"appkey"`
+	APIKey      string `json:"apikey"`
+	APPKey      string `json:"appkey"`
+	Aggregation string `json:"aggregation,omitempty"`
 }
 
 type datapoint struct {
@@ -368,6 +369,10 @@ func (d *Datadog) ConvertPodsMetricName(metricName string, reverse bool) metricp
 	return nil
 }
 
-func (d *Datadog) AddSumAggregator(metricName string) string {
-	return "sum:" + metricName
+func (d *Datadog) AddAggregator(metricName string) string {
+	aggregation := d.Aggregation
+	if aggregation == "" {
+		aggregation = "sum"
+	}
+	return aggregation + ":" + metricName
 }

--- a/ihpa-controller/controllers/metricprovider/metricprovider.go
+++ b/ihpa-controller/controllers/metricprovider/metricprovider.go
@@ -12,8 +12,10 @@ type MetricProvider interface {
 	ConvertObjectMetricName(metricName string, reverse bool) MetricIdentifier
 	// ConvertPodsMetricName convert given name to provider depended name for Pods type.
 	ConvertPodsMetricName(metricName string, reverse bool) MetricIdentifier
-	// AddSumAggregator add sum aggregator to metric name to get sum of metric point.
-	AddSumAggregator(metricName string) string
+	// AddAggregator adds an aggregation function to the metric name.
+	// The aggregation function is determined by the provider's configuration
+	// (e.g., "sum", "min", "max", "count", "avg").
+	AddAggregator(metricName string) string
 }
 
 type MetricIdentifier interface {

--- a/ihpa-controller/controllers/metricprovider/prometheus/prometheus.go
+++ b/ihpa-controller/controllers/metricprovider/prometheus/prometheus.go
@@ -40,6 +40,7 @@ func (mi *metricIdentifier) GetScale() int   { return mi.scale }
 type Prometheus struct {
 	URL            string `json:"url"`
 	PushgatewayURL string `json:"pushgatewayUrl"`
+	Aggregation    string `json:"aggregation,omitempty"`
 }
 
 type queryResponse struct {
@@ -211,7 +212,11 @@ func (p *Prometheus) ConvertPodsMetricName(metricName string, reverse bool) metr
 	return nil
 }
 
-// AddSumAggregator wraps the metric name with sum() for Prometheus queries.
-func (p *Prometheus) AddSumAggregator(metricName string) string {
-	return fmt.Sprintf("sum(%s)", metricName)
+// AddAggregator wraps the metric name with the configured aggregation function for Prometheus queries.
+func (p *Prometheus) AddAggregator(metricName string) string {
+	aggregation := p.Aggregation
+	if aggregation == "" {
+		aggregation = "sum"
+	}
+	return fmt.Sprintf("%s(%s)", aggregation, metricName)
 }

--- a/ihpa-controller/controllers/metricprovider/prometheus/prometheus_test.go
+++ b/ihpa-controller/controllers/metricprovider/prometheus/prometheus_test.go
@@ -230,27 +230,62 @@ func TestPrometheusConvertResourceMetricName(t *testing.T) {
 	}
 }
 
-func TestPrometheusAddSumAggregator(t *testing.T) {
-	p := &Prometheus{}
-
+func TestPrometheusAddAggregator(t *testing.T) {
 	tests := []struct {
-		metricName string
-		expected   string
+		name        string
+		aggregation string
+		metricName  string
+		expected    string
 	}{
 		{
+			name:       "default sum",
 			metricName: "container_cpu_usage_seconds_total",
 			expected:   "sum(container_cpu_usage_seconds_total)",
 		},
 		{
+			name:       "default sum for arbitrary metric",
 			metricName: "ihpa.test.metric",
 			expected:   "sum(ihpa.test.metric)",
+		},
+		{
+			name:        "explicit sum",
+			aggregation: "sum",
+			metricName:  "container_cpu_usage_seconds_total",
+			expected:    "sum(container_cpu_usage_seconds_total)",
+		},
+		{
+			name:        "min aggregation",
+			aggregation: "min",
+			metricName:  "container_cpu_usage_seconds_total",
+			expected:    "min(container_cpu_usage_seconds_total)",
+		},
+		{
+			name:        "max aggregation",
+			aggregation: "max",
+			metricName:  "ihpa.test.metric",
+			expected:    "max(ihpa.test.metric)",
+		},
+		{
+			name:        "count aggregation",
+			aggregation: "count",
+			metricName:  "ihpa.test.metric",
+			expected:    "count(ihpa.test.metric)",
+		},
+		{
+			name:        "avg aggregation",
+			aggregation: "avg",
+			metricName:  "ihpa.test.metric",
+			expected:    "avg(ihpa.test.metric)",
 		},
 	}
 
 	for _, tt := range tests {
-		got := p.AddSumAggregator(tt.metricName)
-		if got != tt.expected {
-			t.Fatalf("AddSumAggregator(%q) = %q, expected %q", tt.metricName, got, tt.expected)
-		}
+		t.Run(tt.name, func(t *testing.T) {
+			p := &Prometheus{Aggregation: tt.aggregation}
+			got := p.AddAggregator(tt.metricName)
+			if got != tt.expected {
+				t.Fatalf("AddAggregator(%q) = %q, expected %q", tt.metricName, got, tt.expected)
+			}
+		})
 	}
 }

--- a/manifests/intelligent-hpa.yaml
+++ b/manifests/intelligent-hpa.yaml
@@ -135,6 +135,16 @@ spec:
                   name:
                     description: Name is a name of provider
                     type: string
+                  aggregation:
+                    description: Aggregation is the aggregation function used when
+                      querying metrics. Valid values are: sum, min, max, count, avg.
+                    enum:
+                    - sum
+                    - min
+                    - max
+                    - count
+                    - avg
+                    type: string
                   prometheus:
                     description: PrometheusProviderSource defines parameters for accessing
                       Prometheus.
@@ -390,6 +400,16 @@ spec:
                     type: object
                   name:
                     description: Name is a name of provider
+                    type: string
+                  aggregation:
+                    description: Aggregation is the aggregation function used when
+                      querying metrics. Valid values are: sum, min, max, count, avg.
+                    enum:
+                    - sum
+                    - min
+                    - max
+                    - count
+                    - avg
                     type: string
                   prometheus:
                     description: PrometheusProviderSource defines parameters for accessing
@@ -8022,6 +8042,16 @@ spec:
                   name:
                     description: Name is a name of provider
                     type: string
+                  aggregation:
+                    description: Aggregation is the aggregation function used when
+                      querying metrics. Valid values are: sum, min, max, count, avg.
+                    enum:
+                    - sum
+                    - min
+                    - max
+                    - count
+                    - avg
+                    type: string
                   prometheus:
                     description: PrometheusProviderSource defines parameters for accessing
                       Prometheus.
@@ -9545,6 +9575,16 @@ spec:
                   name:
                     description: Name is a name of provider
                     type: string
+                  aggregation:
+                    description: Aggregation is the aggregation function used when
+                      querying metrics. Valid values are: sum, min, max, count, avg.
+                    enum:
+                    - sum
+                    - min
+                    - max
+                    - count
+                    - avg
+                    type: string
                   prometheus:
                     description: PrometheusProviderSource defines parameters for accessing
                       Prometheus.
@@ -10161,6 +10201,16 @@ spec:
                     type: object
                   name:
                     description: Name is a name of provider
+                    type: string
+                  aggregation:
+                    description: Aggregation is the aggregation function used when
+                      querying metrics. Valid values are: sum, min, max, count, avg.
+                    enum:
+                    - sum
+                    - min
+                    - max
+                    - count
+                    - avg
                     type: string
                   prometheus:
                     description: PrometheusProviderSource defines parameters for accessing


### PR DESCRIPTION
## 概要

Issue #17 の対応です。

従来、メトリクスの集計関数は `sum` 固定でした（Datadog: `sum:metric`, Prometheus: `sum(metric)`）。本PRでは IHPA プロパティから集計関数を指定できるようにします。

## 変更内容

### CRDフィールド追加
- `MetricProvider.Aggregation` フィールドを v1beta1/v1beta2 に追加
  - 許容値: `sum`, `min`, `max`, `count`, `avg` (default: `sum`)
  - kubebuilder validation enum を設定

### プロバイダー実装
- `MetricProvider` インターフェースの `AddSumAggregator()` を `AddAggregator()` にリネーム
- Datadog: `${aggregation}:${metricName}` 形式（例: `avg:nginx.net.request_per_s`）
- Prometheus: `${aggregation}(${metricName})` 形式（例: `avg(container_cpu_usage_seconds_total)`）
- 両プロバイダーとも `Aggregation` フィールドを追加し、`ConvertMetricProvider` で伝達

### CRDマニフェスト更新
- IHPA, Estimator, FittingJob のCRD YAML に `aggregation` フィールドを追加

### テスト
- `TestConvertMetricProvider`: aggregation フィールド伝達のテストケース追加
- `TestPrometheusAddAggregator`: 全集計関数（sum/min/max/count/avg）のテスト

### ドキュメント
- README.md / README-jp.md に `aggregation` フィールドの説明と使用例を追加

## 使用例

```yaml
metricProvider:
  name: datadog
  aggregation: avg
  datadog:
    apikey: xxx
    appkey: yyy
```

## テスト結果

```
=== RUN   TestConvertMetricProvider
--- PASS (4 subtests)
=== RUN   TestPrometheusAddAggregator
--- PASS (7 subtests)
```

## 関連Issue

Closes #17