### PR TITLE
feat: support Object and Pods metric types in HPA selector

### DIFF
--- a/ihpa-controller/controllers/intelligenthorizontalpodautoscaler_generator_impl.go
+++ b/ihpa-controller/controllers/intelligenthorizontalpodautoscaler_generator_impl.go
@@ -209,7 +209,7 @@ func (g *ihpaGeneratorImpl) generateForecastedMetricSpec(metric *autoscalingv2be
 		}
 		// clear utilization field
 		metricTarget.AverageUtilization = nil
-	} else if metric.Type == "External" {
+	} else if metric.Type == "External" || metric.Type == "Object" || metric.Type == "Pods" {
 		switch metricTarget.Type {
 		case "AverageValue":
 			avgValue = metricTarget.AverageValue.DeepCopy()
@@ -293,7 +293,7 @@ func (g *ihpaGeneratorImpl) fittingJobResource(metric *ihpav1beta2.ExtendedMetri
 }
 
 // convertMetricSpecToIdentifier convert metric name to special name which is dedicated to metric provider.
-// Currently, Resource and External are supported only.
+// Resource, External, Object, and Pods metric types are supported.
 // For example, "cpu" in Resource is convert to "kubernetes.cpu.usage.total" in Datadog.
 func (g *ihpaGeneratorImpl) convertMetricSpecToIdentifier(metric *autoscalingv2beta2.MetricSpec) (*autoscalingv2beta2.MetricIdentifier, error) {
 	metricIdentifier := &autoscalingv2beta2.MetricIdentifier{}
@@ -301,12 +301,19 @@ func (g *ihpaGeneratorImpl) convertMetricSpecToIdentifier(metric *autoscalingv2b
 	case "Resource":
 		mp := mpconfig.ConvertMetricProvider(g.ihpa.Spec.MetricProvider.DeepCopy()).ActiveProvider()
 		mi := mp.ConvertResourceMetricName(metric.Resource.Name.String(), false)
+		if mi == nil {
+			return nil, fmt.Errorf("correspond metric name is not found for resource metric: %s", metric.Resource.Name.String())
+		}
 		filters := g.uniqueMetricFilters()
 
 		metricIdentifier.Name = mi.GetName()
 		metricIdentifier.Selector = &metav1.LabelSelector{MatchLabels: filters}
 	case "External":
 		metricIdentifier = metric.External.Metric.DeepCopy()
+	case "Object":
+		metricIdentifier = metric.Object.Metric.DeepCopy()
+	case "Pods":
+		metricIdentifier = metric.Pods.Metric.DeepCopy()
 	default:
 		return nil, fmt.Errorf("%s metric is not supported yet.", metric.Type)
 	}

--- a/ihpa-controller/controllers/intelligenthorizontalpodautoscaler_generator_impl_test.go
+++ b/ihpa-controller/controllers/intelligenthorizontalpodautoscaler_generator_impl_test.go
@@ -1320,7 +1320,27 @@ func TestConvertMetricSpecToIdentifier(t *testing.T) {
 					},
 				},
 			},
-			expected: nil,
+			expected: &autoscalingv2beta2.MetricIdentifier{
+				Name: "requests-per-second",
+			},
+		},
+		{
+			generator: sample2,
+			metric: &autoscalingv2beta2.MetricSpec{
+				Type: "Pods",
+				Pods: &autoscalingv2beta2.PodsMetricSource{
+					Metric: autoscalingv2beta2.MetricIdentifier{
+						Name: "packets-per-second",
+					},
+					Target: autoscalingv2beta2.MetricTarget{
+						Type:         "AverageValue",
+						AverageValue: resource.NewQuantity(100, resource.DecimalSI),
+					},
+				},
+			},
+			expected: &autoscalingv2beta2.MetricIdentifier{
+				Name: "packets-per-second",
+			},
 		},
 	}
 


### PR DESCRIPTION
## 概要

Issue #18 の対応です。

従来、`convertMetricSpecToIdentifier` は `Resource` と `External` メトリクスタイプのみサポートしており、`Object` と `Pods` タイプのメトリクスはエラーになっていました。本PRではこれら2つのメトリクスタイプをサポートします。

## 変更内容

### `convertMetricSpecToIdentifier()` の拡張
- `Object` タイプ: `metric.Object.Metric.DeepCopy()` でメトリクス識別子を取得
- `Pods` タイプ: `metric.Pods.Metric.DeepCopy()` でメトリクス識別子を取得
- `Resource` タイプ: `ConvertResourceMetricName` がnilを返した場合のエラーメッセージを明確化

### `generateForecastedMetricSpec()` の拡張
- `Object` と `Pods` タイプのメトリクスも `External` と同様に `AverageValue` / `Value` ターゲットを処理

### テスト
- 既存の `Object` タイプテストケースを `nil` 期待から成功期待に更新
- `Pods` タイプのテストケースを追加

## 関連Issue

Closes #18