### PR TITLE
feat: write IHPA status to ConfigMap for observability

### DIFF
--- a/docs/ihpa-controller-specification.md
+++ b/docs/ihpa-controller-specification.md
@@ -840,6 +840,23 @@ func sumUpResourceLists(resourceLists []corev1.ResourceList) *corev1.ResourceLis
 - CronJob
 - カスタムリソース
 
+### ステータスConfigMap
+
+IHPA Controllerは各Reconcileループの最後にステータス情報をConfigMapに書き込みます。
+これにより、外部からIHPAの状態を確認できます。
+
+**ConfigMap名:** `ihpa-<ihpa-name>-status`
+
+**ConfigMapのデータ:**
+- `hpaName`: 生成されたHPAリソース名
+- `fittingJobNames`: 生成されたFittingJob名のカンマ区切りリスト
+- `estimatorNames`: 生成されたEstimator名のカンマ区切りリスト
+
+**確認方法:**
+```sh
+kubectl get configmap ihpa-<ihpa-name>-status -n <namespace> -o yaml
+```
+
 ### 今後の改善案
 
 **パフォーマンス最適化:**

--- a/ihpa-controller/controllers/intelligenthorizontalpodautoscaler_controller.go
+++ b/ihpa-controller/controllers/intelligenthorizontalpodautoscaler_controller.go
@@ -260,6 +260,27 @@ func (r *IntelligentHorizontalPodAutoscalerReconciler) Reconcile(req ctrl.Reques
 	}
 	log.V(ResourceMessageLogLevel).Info("successed to apply annotation", fittingJobIDsAnnotation, fjIdsStr)
 
+	// * create/update status configmap
+	statusCM, err := g.StatusConfigMapResource()
+	if err != nil {
+		return ctrl.Result{}, fmt.Errorf("failed to generate status configmap: %w", err)
+	}
+	existingCM := &corev1.ConfigMap{}
+	if err := r.Get(ctx, types.NamespacedName{Namespace: statusCM.GetNamespace(), Name: statusCM.GetName()}, existingCM); apierrors.IsNotFound(err) {
+		log.V(ResourceMessageLogLevel).Info("initialize status configmap", "name", statusCM.GetName())
+		if err := r.Create(ctx, statusCM); err != nil {
+			return ctrl.Result{}, fmt.Errorf("failed to create status configmap: %w", err)
+		}
+	} else if err != nil {
+		return ctrl.Result{}, fmt.Errorf("failed to get status configmap: %w", err)
+	} else {
+		existingCM.Data = statusCM.Data
+		if err := r.Update(ctx, existingCM); err != nil {
+			return ctrl.Result{}, fmt.Errorf("failed to update status configmap: %w", err)
+		}
+	}
+	log.V(ResourceMessageLogLevel).Info("successed to create/update status configmap", "name", statusCM.GetName())
+
 	return ctrl.Result{}, nil
 }
 

--- a/ihpa-controller/controllers/intelligenthorizontalpodautoscaler_generator.go
+++ b/ihpa-controller/controllers/intelligenthorizontalpodautoscaler_generator.go
@@ -18,4 +18,7 @@ type IntelligentHorizontalPodAutoscalerGenerator interface {
 	EstimatorResources() ([]*ihpav1beta2.Estimator, error)
 	// RBACResources generate some resource for accessing to ConfigMap from FittingJob.
 	RBACResources() (*corev1.ServiceAccount, *rbacv1.Role, *rbacv1.RoleBinding, error)
+	// StatusConfigMapResource generate a ConfigMap that contains status information
+	// about the reconciled IHPA resources (HPA, FittingJobs, Estimators).
+	StatusConfigMapResource() (*corev1.ConfigMap, error)
 }

--- a/ihpa-controller/controllers/intelligenthorizontalpodautoscaler_generator_impl.go
+++ b/ihpa-controller/controllers/intelligenthorizontalpodautoscaler_generator_impl.go
@@ -454,6 +454,51 @@ func (g *ihpaGeneratorImpl) RBACResources() (*corev1.ServiceAccount, *rbacv1.Rol
 	return &sa, &role, &roleBinding, nil
 }
 
+// StatusConfigMapResource generate a ConfigMap that contains status information
+// about the reconciled IHPA resources (HPA, FittingJobs, Estimators).
+// This ConfigMap is updated at the end of each reconcile loop for observability.
+func (g *ihpaGeneratorImpl) StatusConfigMapResource() (*corev1.ConfigMap, error) {
+	fittingJobResources, err := g.FittingJobResources()
+	if err != nil {
+		return nil, fmt.Errorf("failed to generate fittingjob resources for status: %w", err)
+	}
+	estimatorResources, err := g.EstimatorResources()
+	if err != nil {
+		return nil, fmt.Errorf("failed to generate estimator resources for status: %w", err)
+	}
+
+	fittingJobNames := make([]string, 0, len(fittingJobResources))
+	for _, fj := range fittingJobResources {
+		if fj != nil {
+			fittingJobNames = append(fittingJobNames, fj.GetName())
+		}
+	}
+	estimatorNames := make([]string, 0, len(estimatorResources))
+	for _, est := range estimatorResources {
+		if est != nil {
+			estimatorNames = append(estimatorNames, est.GetName())
+		}
+	}
+
+	data := map[string]string{
+		"hpaName":        g.hpaName(),
+		"fittingJobNames": strings.Join(fittingJobNames, ","),
+		"estimatorNames": strings.Join(estimatorNames, ","),
+	}
+
+	cm := corev1.ConfigMap{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      g.statusConfigMapName(),
+			Namespace: g.ihpa.GetNamespace(),
+		},
+		Data: data,
+	}
+
+	addOwnerReference(&(g.ihpa.TypeMeta), &(g.ihpa.ObjectMeta), &cm)
+
+	return &cm, nil
+}
+
 // uniqueMetricID return identifier for a metric. This ID is used for
 // identification each fittingjob.
 func (g *ihpaGeneratorImpl) uniqueMetricID(metric *autoscalingv2beta2.MetricSpec) string {
@@ -524,6 +569,9 @@ func (g *ihpaGeneratorImpl) ihpaString() string {
 
 func (g *ihpaGeneratorImpl) hpaName() string  { return g.ihpaString() }
 func (g *ihpaGeneratorImpl) rbacName() string { return g.ihpaString() }
+func (g *ihpaGeneratorImpl) statusConfigMapName() string {
+	return sanitizeForKubernetesResourceName(g.ihpaString() + "-status")
+}
 func (g *ihpaGeneratorImpl) configMapName(metric *ihpav1beta2.ExtendedMetricSpec) string {
 	return g.ihpaMetricString(metric.MetricSpec())
 }

--- a/ihpa-controller/controllers/intelligenthorizontalpodautoscaler_generator_impl_test.go
+++ b/ihpa-controller/controllers/intelligenthorizontalpodautoscaler_generator_impl_test.go
@@ -1152,6 +1152,90 @@ func TestRBACResources(t *testing.T) {
 	}
 }
 
+func TestStatusConfigMapResource(t *testing.T) {
+	sample1, sample2 := testIHPAGeneratorSample(t)
+	tests := []struct {
+		name      string
+		generator *ihpaGeneratorImpl
+		expected  *corev1.ConfigMap
+	}{
+		{
+			name:      "sample1",
+			generator: sample1,
+			expected: &corev1.ConfigMap{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      "ihpa-sample1-status",
+					Namespace: "default",
+					OwnerReferences: []metav1.OwnerReference{
+						{
+							APIVersion:         "ihpa.ake.cyberagent.co.jp/v1beta1",
+							Controller:         func(b bool) *bool { return &b }(true),
+							BlockOwnerDeletion: func(b bool) *bool { return &b }(true),
+							Kind:               "IntelligentHorizontalPodAutoscaler.ihpa.ake.cyberagent.co.jp",
+							Name:               "sample1",
+							UID:                "9fc642f3-bb9d-404d-afd5-d04f1d6149ad",
+						},
+					},
+				},
+				Data: map[string]string{
+					"hpaName":         "ihpa-sample1",
+					"fittingJobNames": "ihpa-sample1-cpu",
+					"estimatorNames":  "ihpa-sample1-cpu",
+				},
+			},
+		},
+		{
+			name:      "sample2",
+			generator: sample2,
+			expected: &corev1.ConfigMap{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      "ihpa-sample2-status",
+					Namespace: "web",
+					OwnerReferences: []metav1.OwnerReference{
+						{
+							APIVersion:         "ihpa.ake.cyberagent.co.jp/v1",
+							Controller:         func(b bool) *bool { return &b }(true),
+							BlockOwnerDeletion: func(b bool) *bool { return &b }(true),
+							Kind:               "IntelligentHorizontalPodAutoscaler.ihpa.ake.cyberagent.co.jp",
+							Name:               "sample2",
+							UID:                "9fc642f3-bb9d-404d-afd5-d04f1d6149ad",
+						},
+					},
+				},
+				Data: map[string]string{
+					"hpaName":         "ihpa-sample2",
+					"fittingJobNames": "ihpa-sample2-cpu,ihpa-sample2-memory,ihpa-sample2-nginx-net-request-per-s",
+					"estimatorNames":  "ihpa-sample2-cpu,ihpa-sample2-memory,ihpa-sample2-nginx-net-request-per-s",
+				},
+			},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got, err := tt.generator.StatusConfigMapResource()
+			if err != nil {
+				t.Fatal(err)
+			}
+			if got.Name != tt.expected.Name {
+				t.Errorf("configmap name mismatch: got=%s, exp=%s", got.Name, tt.expected.Name)
+			}
+			if got.Namespace != tt.expected.Namespace {
+				t.Errorf("configmap namespace mismatch: got=%s, exp=%s", got.Namespace, tt.expected.Namespace)
+			}
+			if !reflect.DeepEqual(got.Data, tt.expected.Data) {
+				t.Errorf("configmap data mismatch:\ngot=%#v\nexp=%#v", got.Data, tt.expected.Data)
+			}
+			if len(got.OwnerReferences) != 1 {
+				t.Fatalf("expected 1 owner reference, got %d", len(got.OwnerReferences))
+			}
+			if got.OwnerReferences[0].Name != tt.expected.OwnerReferences[0].Name {
+				t.Errorf("owner reference name mismatch: got=%s, exp=%s", got.OwnerReferences[0].Name, tt.expected.OwnerReferences[0].Name)
+			}
+		})
+	}
+}
+
 func TestGenerateForecastedMetricSpec(t *testing.T) {
 	sample1, sample2 := testIHPAGeneratorSample(t)
 	tests := []struct {


### PR DESCRIPTION
## 概要

Issue #19 の対応です。

従来、IHPA ControllerはReconcile後のリソース状態を外部から確認する手段がありませんでした。本PRでは、Reconcileループの最後にステータス情報をConfigMapに書き込むことで、デバッグや運用時の可観測性を向上させます。

## 変更内容

### ステータスConfigMapの生成
- `StatusConfigMapResource()` メソッドをIHPAジェネレーターに追加
- ConfigMap名: `ihpa-<ihpa-name>-status`
- 以下のステータス情報を記録:
  - `hpaName`: 生成されたHPAリソース名
  - `fittingJobNames`: 生成されたFittingJob名のカンマ区切りリスト
  - `estimatorNames`: 生成されたEstimator名のカンマ区切りリスト
- IHPAリソースへのOwnerReferenceを設定（IHPA削除時にConfigMapも自動削除）

### コントローラーの更新
- Reconcileループの最後（アノテーション更新後）にステータスConfigMapを作成/更新
- 既存のConfigMapが存在する場合は更新、存在しない場合は作成

### テスト
- `TestStatusConfigMapResource` を追加（sample1, sample2の両方をカバー）

### ドキュメント
- `docs/ihpa-controller-specification.md` にステータスConfigMapのセクションを追加

## 確認方法

```sh
kubectl get configmap ihpa-<ihpa-name>-status -n <namespace> -o yaml
```

## 関連Issue

Closes #19