### PR TITLE
chore: remove stale TODO and mark v1beta1 FittingJobConfig as deprecated

### DIFF
--- a/ihpa-controller/api/v1beta1/intelligenthorizontalpodautoscaler_types.go
+++ b/ihpa-controller/api/v1beta1/intelligenthorizontalpodautoscaler_types.go
@@ -60,8 +60,9 @@ type HorizontalPodAutoscalerTemplateSpec struct {
 	Spec autoscalingv2beta2.HorizontalPodAutoscalerSpec `json:"spec,omitempty"`
 }
 
-// TODO: Use fittingJobSpec
-// FittingJobConfig describe base config for fittingJob
+// FittingJobConfig describe base config for fittingJob.
+// Deprecated: v1beta1 uses a single FittingJobConfig for all metrics.
+// In v1beta2, this is replaced by per-metric FittingJobPatchSpec.
 type FittingJobConfig struct {
 	// Seasonality is time span of bunch metrics period.
 	// This is defined as "daily", "weekly", "yearly", "auto".


### PR DESCRIPTION
## 概要

Issue #20 の対応です。

v1beta1の `FittingJobConfig` には `// TODO: Use fittingJobSpec` というTODOコメントがありましたが、v1beta2では `FittingJobPatchSpec`（メトリクスごとの設定）に置き換えられており、v1beta1の `FittingJobConfig` は未使用の残骸となっています。

## 変更内容

- `ihpa-controller/api/v1beta1/intelligenthorizontalpodautoscaler_types.go` の `FittingJobConfig` から古いTODOコメントを削除
- `Deprecated` コメントを追加し、v1beta2の `FittingJobPatchSpec` に置き換えられたことを明記

## 判断理由

- v1beta1は互換性のために残されている旧API
- `FittingJobConfig` フィールドはコントローラーで使用されていない
- v1beta2では `FittingJobPatchSpec` が各メトリクスごとの設定として使用されている
- 完全に削除すると既存のv1beta1リソースとの互換性が失われるため、非推奨として残置

## 関連Issue

Closes #20