### PR TITLE
refactor: clean up MetricProviderConfig and remove stale TODO

### DIFF
--- a/ihpa-controller/controllers/metricprovider/config/config.go
+++ b/ihpa-controller/controllers/metricprovider/config/config.go
@@ -1,19 +1,24 @@
 package config
 
 import (
+	"fmt"
+
 	ihpav1beta2 "github.com/cyberagent-oss/intelligent-hpa/ihpa-controller/api/v1beta2"
 	"github.com/cyberagent-oss/intelligent-hpa/ihpa-controller/controllers/metricprovider"
 	datadogmp "github.com/cyberagent-oss/intelligent-hpa/ihpa-controller/controllers/metricprovider/datadog"
 	prometheusmp "github.com/cyberagent-oss/intelligent-hpa/ihpa-controller/controllers/metricprovider/prometheus"
 )
 
+// MetricProviderConfig holds the configuration for a metric provider.
+// It wraps the concrete provider implementations and exposes them
+// through a unified interface via ActiveProvider().
 type MetricProviderConfig struct {
 	Datadog    *datadogmp.Datadog       `json:"datadog,omitempty"`
 	Prometheus *prometheusmp.Prometheus `json:"prometheus,omitempty"`
 }
 
-// convertMetricProvider converts MetricProvider which is defined for
-// IHPA api to MerticProvider which is defined for FittingJob.
+// ConvertMetricProvider converts a MetricProvider from the IHPA API
+// to a MetricProviderConfig used by FittingJob and Estimator.
 func ConvertMetricProvider(mp *ihpav1beta2.MetricProvider) *MetricProviderConfig {
 	metricProvider := MetricProviderConfig{}
 	if mp.ProviderSource.Datadog != nil {
@@ -34,12 +39,23 @@ func ConvertMetricProvider(mp *ihpav1beta2.MetricProvider) *MetricProviderConfig
 	return &metricProvider
 }
 
-// TODO: bad code because of bad struct metricProvider
+// ActiveProvider returns the active metric provider as a MetricProvider
+// interface. Returns nil if no provider is configured.
 func (mp *MetricProviderConfig) ActiveProvider() metricprovider.MetricProvider {
-	if mp.Datadog != nil {
+	switch {
+	case mp.Datadog != nil:
 		return mp.Datadog
-	} else if mp.Prometheus != nil {
+	case mp.Prometheus != nil:
 		return mp.Prometheus
+	default:
+		return nil
+	}
+}
+
+// Validate returns an error if no provider is configured.
+func (mp *MetricProviderConfig) Validate() error {
+	if mp.Datadog == nil && mp.Prometheus == nil {
+		return fmt.Errorf("no metric provider is configured")
 	}
 	return nil
 }

--- a/ihpa-controller/controllers/metricprovider/config/config_test.go
+++ b/ihpa-controller/controllers/metricprovider/config/config_test.go
@@ -89,3 +89,83 @@ func TestConvertMetricProvider(t *testing.T) {
 		})
 	}
 }
+
+func TestActiveProvider(t *testing.T) {
+	tests := []struct {
+		name     string
+		mp       *MetricProviderConfig
+		isNil    bool
+	}{
+		{
+			name: "datadog provider",
+			mp: &MetricProviderConfig{
+				Datadog: &datadogmp.Datadog{APIKey: "xxx", APPKey: "yyy"},
+			},
+			isNil: false,
+		},
+		{
+			name: "prometheus provider",
+			mp: &MetricProviderConfig{
+				Prometheus: &prometheusmp.Prometheus{URL: "http://prometheus:9090"},
+			},
+			isNil: false,
+		},
+		{
+			name:  "no provider",
+			mp:    &MetricProviderConfig{},
+			isNil: true,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got := tt.mp.ActiveProvider()
+			if tt.isNil && got != nil {
+				t.Fatalf("expected nil, got %v", got)
+			}
+			if !tt.isNil && got == nil {
+				t.Fatalf("expected non-nil, got nil")
+			}
+		})
+	}
+}
+
+func TestValidate(t *testing.T) {
+	tests := []struct {
+		name    string
+		mp      *MetricProviderConfig
+		wantErr bool
+	}{
+		{
+			name: "datadog provider valid",
+			mp: &MetricProviderConfig{
+				Datadog: &datadogmp.Datadog{APIKey: "xxx", APPKey: "yyy"},
+			},
+			wantErr: false,
+		},
+		{
+			name: "prometheus provider valid",
+			mp: &MetricProviderConfig{
+				Prometheus: &prometheusmp.Prometheus{URL: "http://prometheus:9090"},
+			},
+			wantErr: false,
+		},
+		{
+			name:    "no provider invalid",
+			mp:      &MetricProviderConfig{},
+			wantErr: true,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			err := tt.mp.Validate()
+			if tt.wantErr && err == nil {
+				t.Fatalf("expected error, got nil")
+			}
+			if !tt.wantErr && err != nil {
+				t.Fatalf("expected no error, got %v", err)
+			}
+		})
+	}
+}


### PR DESCRIPTION
## 概要

Issue #21 の対応です。

`MetricProviderConfig` 構造体に `TODO: bad code because of bad struct metricProvider` というコメントがありました。本PRではコードを整理し、保守性を向上させます。

## 変更内容

### リファクタリング
- `ActiveProvider()` メソッドを if-else チェーンから switch 文に変更し、可読性を向上
- 古いTODOコメントを削除
- `MetricProviderConfig` と `ConvertMetricProvider` にドキュメントコメントを追加

### 新機能
- `Validate()` メソッドを追加: プロバイダーが設定されていない場合にエラーを返す

### テスト
- `TestActiveProvider`: Datadog/Prometheus/未設定の各ケースを検証
- `TestValidate`: プロバイダーあり/なしの各ケースを検証

## 関連Issue

Closes #21