### PR TITLE
feat: return MD5 hash from model dump and verify integrity on load

### DIFF
--- a/fittingjob/fittingjob/model.py
+++ b/fittingjob/fittingjob/model.py
@@ -1,5 +1,6 @@
 #!/usr/bin/env python3
 
+import hashlib
 import pickle
 
 from fbprophet import Prophet, diagnostics
@@ -51,17 +52,36 @@ class IHPAModel:
         selected.drop(columns='ds')
         return selected
 
-    def dump(self, path: str):
-        # TODO: return file md5 hash and
-        #       check the integrity of the model when loading
+    def dump(self, path: str) -> str:
+        """Dump the model to a file and return its MD5 hash."""
         with open(path, mode='wb') as f:
             pickle.dump(self, f)
+        return self.__file_md5(path)
 
-    def load(self, path: str):
+    def load(self, path: str, expected_md5: str = None):
+        """Load the model from a file.
+
+        If expected_md5 is provided, the file integrity is verified
+        before loading. A ValueError is raised if the hash does not match.
+        """
+        if expected_md5 is not None:
+            actual_md5 = self.__file_md5(path)
+            if actual_md5 != expected_md5:
+                raise ValueError(
+                    f'md5 hash mismatch: expected={expected_md5}, actual={actual_md5}')
         with open(path, mode='rb') as f:
             m = pickle.load(f)
         self.model = m.model
         self.train = m.train
+
+    @staticmethod
+    def __file_md5(path: str) -> str:
+        """Compute the MD5 hash of a file."""
+        h = hashlib.md5()
+        with open(path, mode='rb') as f:
+            for chunk in iter(lambda: f.read(8192), b''):
+                h.update(chunk)
+        return h.hexdigest()
 
     def cross_validation(
             self,


### PR DESCRIPTION
## 概要

Issue #23 の対応です。

`fittingjob/fittingjob/model.py` の `dump()` と `load()` メソッドにMD5ハッシュの返却と整合性チェック機能を実装しました。

## 変更内容

### `dump(path)` メソッド
- モデルをファイルに保存後、そのファイルのMD5ハッシュを計算して返します
- 戻り値: MD5ハッシュ文字列（16進数32文字）

### `load(path, expected_md5=None)` メソッド
- `expected_md5` パラメータを追加（オプショナル）
- `expected_md5` が指定された場合、ロード前にファイルのMD5ハッシュを計算し、一致しない場合は `ValueError` を発生させます
- `expected_md5` が指定されない場合は従来通り動作します（後方互換性）

### `__file_md5(path)` プライベートメソッド
- ファイルのMD5ハッシュを8192バイト単位で計算するヘルパーメソッド
- メモリ効率を考慮し、チャンク単位で読み込み

## 使用例

```python
m = IHPAModel()
m.fit(df)
md5 = m.dump('/path/to/model.pkl')  # MD5ハッシュを返却

m2 = IHPAModel()
m2.load('/path/to/model.pkl', expected_md5=md5)  # 整合性チェック
```

## 関連Issue

Closes #23