### PR TITLE
ci: upgrade Go to 1.22 in generate-manifest job

### DIFF
--- a/.github/workflows/build-and-push.yaml
+++ b/.github/workflows/build-and-push.yaml
@@ -129,7 +129,7 @@ jobs:
       - name: Set up Go
         uses: actions/setup-go@v5
         with:
-          go-version: '1.13'
+          go-version: '1.22'
 
       - name: Install kustomize
         run: |


### PR DESCRIPTION
## Summary

The `generate-manifest` job in the CI workflow was failing because Go 1.13 does not support the `go install package@version` syntax (requires Go 1.16+).

## Change

- Upgrade Go version from `1.13` to `1.22` in the `generate-manifest` job of `.github/workflows/build-and-push.yaml`

This is a pre-existing issue (not introduced by PR #35), but it prevents the manifest from being auto-updated after image builds succeed.

## Test plan

- [ ] CI passes, including the `generate-manifest` job